### PR TITLE
Implement node position persistence

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,35 @@
+import { Network, DataSet } from "vis-network/standalone";
+
+const container = document.getElementById("mynetwork");
+const nodes = new DataSet([]);
+const edges = new DataSet([]);
+
+const data = { nodes, edges };
+const options = {};
+const network = new Network(container, data, options);
+
+// Persist node positions on drag end
+network.on("dragEnd", (params) => {
+  if (params.nodes && params.nodes.length > 0) {
+    params.nodes.forEach((id) => {
+      const pos = network.getPositions([id])[id];
+      nodes.update({ id, x: pos.x, y: pos.y });
+    });
+  }
+});
+
+export function addNode(node) {
+  // expects node object containing {id, label, x, y}
+  nodes.add(node);
+}
+
+export function addNodes(list) {
+  list.forEach((n) => nodes.add(n));
+}
+
+export function load(data) {
+  nodes.clear();
+  edges.clear();
+  if (data.nodes) data.nodes.forEach((n) => nodes.add(n));
+  if (data.edges) data.edges.forEach((e) => edges.add(e));
+}


### PR DESCRIPTION
## Summary
- add `src/main.js` for vis network interaction
- store node `{x, y}` on `dragEnd`
- use stored positions when adding or loading nodes

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684146b15d7c832f87321ab6e63d428d