### PR TITLE
Add basic project save/load functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Välj-väg-verktyg</title>
+</head>
+<body>
+  <button id="save">Save</button>
+  <button id="load-button">Load</button>
+  <input type="file" id="load" style="display:none" />
+  <a id="download" style="display:none"></a>
+
+  <script type="module" src="../src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,82 @@
+class DataSet {
+  constructor(items = []) {
+    this.items = new Map();
+    items.forEach(item => this.items.set(item.id, { ...item }));
+  }
+  add(item) { this.items.set(item.id, { ...item }); }
+  get() { return Array.from(this.items.values()); }
+  clear() { this.items.clear(); }
+}
+
+let nodes = new DataSet();
+let nodeCounter = 0;
+
+function rebuildEdges() {
+  // Placeholder for building edges based on nodes
+}
+
+async function saveProject() {
+  const data = {
+    nodes: nodes.get(),
+    settings: { nextNodeId: nodeCounter }
+  };
+  const json = JSON.stringify(data, null, 2);
+  const filename = `${Date.now()}-project.json`;
+
+  if (window.showSaveFilePicker) {
+    try {
+      const handle = await window.showSaveFilePicker({
+        suggestedName: filename,
+        types: [{ description: 'JSON', accept: { 'application/json': ['.json'] } }]
+      });
+      const writable = await handle.createWritable();
+      await writable.write(json);
+      await writable.close();
+    } catch (err) {
+      console.error('Save failed', err);
+    }
+  } else {
+    let link = document.getElementById('download');
+    if (!link) {
+      link = document.createElement('a');
+      link.id = 'download';
+      link.style.display = 'none';
+      document.body.appendChild(link);
+    }
+    const blob = new Blob([json], { type: 'application/json' });
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(link.href), 0);
+  }
+}
+
+function loadProject(event) {
+  const input = event.target;
+  const file = input.files && input.files[0];
+  if (!file) return;
+
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      nodes = new DataSet(data.nodes || []);
+      nodeCounter = data.settings?.nextNodeId || 0;
+      rebuildEdges();
+    } catch (err) {
+      console.error('Load failed', err);
+    }
+  };
+  reader.readAsText(file);
+  input.value = '';
+}
+
+const saveBtn = document.getElementById('save');
+const loadInput = document.getElementById('load');
+const loadButton = document.getElementById('load-button');
+
+if (saveBtn) saveBtn.addEventListener('click', saveProject);
+if (loadInput) loadInput.addEventListener('change', loadProject);
+if (loadButton) loadButton.addEventListener('click', () => loadInput && loadInput.click());
+
+export { saveProject, loadProject };


### PR DESCRIPTION
## Summary
- add basic HTML with Save/Load controls
- implement saveProject and loadProject in `src/main.js`
- hook up UI events to these functions

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684146bc853c832f9760b1fecc7cc4a8