### PR TITLE
Expand ReactFlow area and parse node links

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -146,6 +146,7 @@ export default function App() {
       <main>
         <div id="graph">
           <ReactFlow
+            style={{ width: '100%', height: '100%' }}
             nodes={nodes}
             edges={edges}
             onNodesChange={onNodesChange}

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
+html,
 body {
   margin: 0;
-  min-height: 100vh;
+  height: 100vh;
   display: flex;
   flex-direction: column;
 }
@@ -15,17 +16,20 @@ header {
 main {
   flex: 1;
   display: flex;
+  overflow: hidden;
 }
 
 #graph {
   flex: 1;
   border-right: 1px solid #ccc;
+  height: 100%;
 }
 
 #editor {
   width: 300px;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 #editor h2 {


### PR DESCRIPTION
## Summary
- make body take the full viewport height
- ensure graph area uses full height and the editor can scroll
- size the ReactFlow component to match its container

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684156bc69e4832fa98ac2e72ff5d7f2