### PR TITLE
Improve graph editor theme and layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
-  "name": "temp-app",
+  "name": "valj-vag-verktyg",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp-app",
+      "name": "valj-vag-verktyg",
       "version": "0.0.0",
       "dependencies": {
+        "marked": "^15.0.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "reactflow": "^11.11.4"
@@ -2706,6 +2707,18 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "reactflow": "^11.11.4"
+    "reactflow": "^11.11.4",
+    "marked": "^15.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,9 +2,11 @@ import { useState, useCallback } from 'react'
 import ReactFlow, {
   applyNodeChanges,
   applyEdgeChanges,
+  Background,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import './App.css'
+import NodeCard from './NodeCard.jsx'
 
 function scanEdges(nodes) {
   const pattern = /\[#(\d{3})]/g
@@ -28,6 +30,7 @@ function scanEdges(nodes) {
 }
 
 export default function App() {
+  const nodeTypes = { card: NodeCard }
   const [nodes, setNodes] = useState([])
   const [edges, setEdges] = useState([])
   const [nextId, setNextId] = useState(1)
@@ -47,9 +50,16 @@ export default function App() {
   const addNode = () => {
     const id = String(nextId).padStart(3, '0')
     setNodes(ns => {
+      let position = { x: 0, y: 0 }
+      if (currentId) {
+        const cur = ns.find(n => n.id === currentId)
+        if (cur) {
+          position = { x: cur.position.x + 300, y: cur.position.y }
+        }
+      }
       const updated = [
         ...ns,
-        { id, position: { x: 0, y: 0 }, data: { label: `#${id}`, text: '' } },
+        { id, type: 'card', position, data: { text: '' } },
       ]
       setEdges(scanEdges(updated))
       return updated
@@ -112,8 +122,9 @@ export default function App() {
       const data = JSON.parse(json)
       const loaded = (data.nodes || []).map(n => ({
         id: n.id,
+        type: 'card',
         position: n.position || { x: 0, y: 0 },
-        data: { label: `#${n.id}`, text: n.text || '' },
+        data: { text: n.text || '' },
       }))
       setNodes(loaded)
       setEdges(scanEdges(loaded))
@@ -152,8 +163,11 @@ export default function App() {
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onNodeClick={onNodeClick}
+            nodeTypes={nodeTypes}
             fitView
-          />
+          >
+            <Background color="#374151" variant="dots" gap={16} size={1} />
+          </ReactFlow>
         </div>
         <section id="editor">
           <h2 id="nodeId">#{currentId || '000'}</h2>

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,0 +1,35 @@
+import { memo } from 'react'
+import { Handle, Position } from 'reactflow'
+import { marked } from 'marked'
+
+function parseText(text = '') {
+  const tokens = marked.lexer(text)
+  let title = ''
+  let foundTitle = false
+  const bodyParts = []
+  for (const t of tokens) {
+    if (!foundTitle && t.type === 'heading') {
+      title = t.text
+      foundTitle = true
+    } else if (t.type === 'paragraph' || t.type === 'text') {
+      bodyParts.push(t.text)
+    }
+  }
+  const body = bodyParts.join(' ').trim()
+  return { title, snippet: body.slice(0, 50) }
+}
+
+const NodeCard = memo(({ id, data }) => {
+  const { title, snippet } = parseText(data.text)
+  return (
+    <div className="node-card">
+      <div className="node-id">[{id}]</div>
+      {title && <div className="node-title">{title}</div>}
+      {snippet && <div className="node-preview">{snippet}</div>}
+      <Handle type="source" position={Position.Right} />
+      <Handle type="target" position={Position.Left} />
+    </div>
+  )
+})
+
+export default NodeCard

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,9 @@ html,
 body {
   margin: 0;
   height: 100vh;
+  background: #0d1117;
+  color: #f9fafb;
+  font-family: system-ui, sans-serif;
 }
 #root {
   display: flex;
@@ -13,7 +16,7 @@ header {
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #374151;
 }
 
 main {
@@ -24,7 +27,6 @@ main {
 
 #graph {
   flex: 1;
-  border-right: 1px solid #ccc;
   height: 100%;
 }
 
@@ -33,12 +35,14 @@ main {
   display: flex;
   flex-direction: column;
   overflow-y: auto;
+  border-left: 1px solid #374151;
+  background: #161b22;
 }
 
 #editor h2 {
   margin: 0;
   padding: 0.5rem;
-  border-bottom: 1px solid #ccc;
+  border-bottom: 1px solid #374151;
 }
 
 #text {
@@ -74,4 +78,32 @@ main {
   padding: 0.5rem;
   white-space: pre-wrap;
   user-select: text;
+}
+
+.node-card {
+  width: 220px;
+  background: #1f2937;
+  color: #f9fafb;
+  border: 1px solid #374151;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+  padding: 0.5rem;
+  font-size: 0.8rem;
+}
+.node-card .node-id {
+  font-family: monospace;
+  font-size: 0.75rem;
+  opacity: 0.8;
+  margin-bottom: 0.25rem;
+}
+.node-card .node-title {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.node-card .node-preview {
+  max-height: 4em;
+  overflow: auto;
 }


### PR DESCRIPTION
## Summary
- add custom NodeCard ReactFlow component
- use marked to parse node preview content
- update graph to dark theme with dotted background
- shift new nodes to the right of selection
- style node cards with width constraints and scrollable text

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68415edf8584832f9539ea1517271176