### PR TITLE
Use NodeCard as the default node type

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ function scanEdges(nodes) {
 }
 
 export default function App() {
-  const nodeTypes = { card: NodeCard }
+  const nodeTypes = { default: NodeCard }
   const [nodes, setNodes] = useState([])
   const [edges, setEdges] = useState([])
   const [nextId, setNextId] = useState(1)
@@ -59,7 +59,7 @@ export default function App() {
       }
       const updated = [
         ...ns,
-        { id, type: 'card', position, data: { text: '' } },
+        { id, position, data: { text: '' } },
       ]
       setEdges(scanEdges(updated))
       return updated
@@ -122,7 +122,6 @@ export default function App() {
       const data = JSON.parse(json)
       const loaded = (data.nodes || []).map(n => ({
         id: n.id,
-        type: 'card',
         position: n.position || { x: 0, y: 0 },
         data: { text: n.text || '' },
       }))


### PR DESCRIPTION
## Summary
- configure React Flow to use `NodeCard` for the default node type
- remove explicit `type: 'card'` assignments when adding or loading nodes

## Testing
- `npm run build` *(fails: `vite` not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68416223228c832fbac2072826672fbb