### PR TITLE
Fix regex scanning for edges

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ function scanEdges(nodes) {
   const edges = []
   for (const n of nodes) {
     const text = n.data.text || ''
+    pattern.lastIndex = 0
     let match
     while ((match = pattern.exec(text))) {
       const target = match[1]


### PR DESCRIPTION
## Summary
- reset regex index when scanning nodes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68416871b700832fa2b7f6c6e3705560