### PR TITLE
Refactor parseText into shared util

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css'
 import './App.css'
 import NodeCard from './NodeCard.jsx'
+import { parseText } from './parseText.js'
 import pkg from '../package.json'
 
 function scanEdges(nodes) {
@@ -39,6 +40,7 @@ export default function App() {
   const [currentId, setCurrentId] = useState(null)
   const [text, setText] = useState('')
   const [showModal, setShowModal] = useState(false)
+  const { title } = useMemo(() => parseText(text), [text])
 
   const onNodesChange = useCallback(
     changes => setNodes(ns => applyNodeChanges(changes, ns)),
@@ -186,7 +188,7 @@ export default function App() {
           </ReactFlow>
         </div>
         <section id="editor">
-          <h2 id="nodeId">#{currentId || '000'}</h2>
+          <h2 id="nodeId">#{currentId || '000'} {title}</h2>
           <textarea id="text" value={text} onChange={onTextChange} />
         </section>
       </main>

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,23 +1,6 @@
 import { memo } from 'react'
 import { Handle, Position } from 'reactflow'
-import { marked } from 'marked'
-
-function parseText(text = '') {
-  const tokens = marked.lexer(text)
-  let title = ''
-  let foundTitle = false
-  const bodyParts = []
-  for (const t of tokens) {
-    if (!foundTitle && t.type === 'heading') {
-      title = t.text
-      foundTitle = true
-    } else if (t.type === 'paragraph' || t.type === 'text') {
-      bodyParts.push(t.text)
-    }
-  }
-  const body = bodyParts.join(' ').trim()
-  return { title, snippet: body.slice(0, 50) }
-}
+import { parseText } from './parseText.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { title, snippet } = parseText(data.text)

--- a/src/parseText.js
+++ b/src/parseText.js
@@ -1,0 +1,18 @@
+import { marked } from 'marked'
+
+export function parseText(text = '') {
+  const tokens = marked.lexer(text)
+  let title = ''
+  let foundTitle = false
+  const bodyParts = []
+  for (const t of tokens) {
+    if (!foundTitle && t.type === 'heading') {
+      title = t.text
+      foundTitle = true
+    } else if (t.type === 'paragraph' || t.type === 'text') {
+      bodyParts.push(t.text)
+    }
+  }
+  const body = bodyParts.join(' ').trim()
+  return { title, snippet: body.slice(0, 50) }
+}


### PR DESCRIPTION
## Summary
- extract `parseText` helper from `NodeCard.jsx`
- reuse the helper in `NodeCard` and `App`
- show current node title in editor heading

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684178b6cf38832f8365ae1f9ca73bc9