### PR TITLE
Combine ID and title header

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -6,8 +6,10 @@ const NodeCard = memo(({ id, data, selected }) => {
   const { title, snippet } = parseText(data.text)
   return (
     <div className={`node-card${selected ? ' selected' : ''}`}>
-      <div className="node-id">[{id}]</div>
-      {title && <div className="node-title">{title}</div>}
+      <div className="node-header">
+        <span className="node-id">[{id}]</span>
+        {title && <span className="node-title">{title}</span>}
+      </div>
       {snippet && <div className="node-preview">{snippet}</div>}
       <Handle type="source" position={Position.Right} />
       <Handle type="target" position={Position.Left} />

--- a/src/index.css
+++ b/src/index.css
@@ -97,7 +97,13 @@ main {
   font-family: monospace;
   font-size: 0.75rem;
   opacity: 0.8;
+  margin-right: 0.25rem;
+}
+.node-card .node-header {
   margin-bottom: 0.25rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .node-card .node-title {
   font-weight: bold;


### PR DESCRIPTION
## Summary
- show node id and title on one line
- add `.node-header` style with text overflow handling

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684179d7de38832f9a54802d2ebe13ae