### PR TITLE
Add arrowheads to flow edges

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import ReactFlow, {
   applyNodeChanges,
   applyEdgeChanges,
   Background,
+  MarkerType,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import './App.css'
@@ -34,6 +35,10 @@ function scanEdges(nodes) {
 
 export default function App() {
   const nodeTypes = useMemo(() => ({ card: NodeCard }), [])
+  const defaultEdgeOptions = useMemo(
+    () => ({ markerEnd: { type: MarkerType.ArrowClosed } }),
+    []
+  )
   const [nodes, setNodes] = useState([])
   const [edges, setEdges] = useState([])
   const [nextId, setNextId] = useState(1)
@@ -198,6 +203,7 @@ export default function App() {
             style={{ width: '100%', height: '100%' }}
             nodes={nodes}
             edges={edges}
+            defaultEdgeOptions={defaultEdgeOptions}
             onNodesChange={onNodesChange}
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}


### PR DESCRIPTION
## Summary
- show connection direction with arrowheads

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417da5512c832f940b2296758def1b