### PR TITLE
Add node title display after number

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -7,7 +7,7 @@ const NodeCard = memo(({ id, data, selected }) => {
   return (
     <div className={`node-card${selected ? ' selected' : ''}`}>
       <div className="node-header">
-        <span className="node-id">[{id}]</span>
+        <span className="node-id">{id}</span>
         {title && <span className="node-title">{title}</span>}
       </div>
       {snippet && <div className="node-preview">{snippet}</div>}


### PR DESCRIPTION
## Summary
- show the node ID without brackets
- display any parsed title after the number

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68417f882074832f9b33ed5f5f41bae4