### PR TITLE
Add node title support

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -3,12 +3,12 @@ import { Handle, Position } from 'reactflow'
 import { parseText } from './parseText.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
-  const { title, snippet } = parseText(data.text)
+  const { snippet } = parseText(data.text)
   return (
     <div className={`node-card${selected ? ' selected' : ''}`}>
       <div className="node-header">
         <span className="node-id">#{id}</span>
-        {title && <span className="node-title">{title}</span>}
+        {data.title && <span className="node-title">{data.title}</span>}
       </div>
       {snippet && <div className="node-preview">{snippet}</div>}
       <Handle type="source" position={Position.Right} />

--- a/src/parseText.js
+++ b/src/parseText.js
@@ -2,17 +2,12 @@ import { marked } from 'marked'
 
 export function parseText(text = '') {
   const tokens = marked.lexer(text)
-  let title = ''
-  let foundTitle = false
   const bodyParts = []
   for (const t of tokens) {
-    if (!foundTitle && t.type === 'heading') {
-      title = t.text
-      foundTitle = true
-    } else if (t.type === 'paragraph' || t.type === 'text') {
+    if (t.type === 'paragraph' || t.type === 'text') {
       bodyParts.push(t.text)
     }
   }
   const body = bodyParts.join(' ').trim()
-  return { title, snippet: body.slice(0, 50) }
+  return { snippet: body.slice(0, 50) }
 }


### PR DESCRIPTION
## Summary
- track a `title` per node and show an editor field
- include title in save/load and linear view
- update NodeCard display
- simplify `parseText` to return snippet only

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684186f07f20832f960c57555144c91b