### PR TITLE
Update parseText to only return snippet

### DIFF
--- a/src/parseText.js
+++ b/src/parseText.js
@@ -8,6 +8,6 @@ export function parseText(text = '') {
       bodyParts.push(t.text)
     }
   }
-  const body = bodyParts.join(' ').trim()
-  return { snippet: body.slice(0, 50) }
+  const snippet = bodyParts.join(' ').trim().slice(0, 50)
+  return { snippet }
 }


### PR DESCRIPTION
## Summary
- simplify parseText return object to `{ snippet }`
- keep NodeCard snippet parsing working

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684187c1ec4c832fa6f52f4c1968eb16