### PR TITLE
Improve link creation with bare # references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ npm run dev
 npm run build
 ```
 
-Project files can be saved and loaded using the buttons in the interface. Nodes link to each other using references like `[#001]` inside the node text.
+Project files can be saved and loaded using the buttons in the interface. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,7 +11,7 @@ import NodeCard from './NodeCard.jsx'
 import pkg from '../package.json'
 
 function scanEdges(nodes) {
-  const pattern = /\[#(\d{3})]/g
+  const pattern = /\[#(\d{3})]|#(\d{3})/g
   const unique = new Set()
   const edges = []
   for (const n of nodes) {
@@ -19,7 +19,7 @@ function scanEdges(nodes) {
     pattern.lastIndex = 0
     let match
     while ((match = pattern.exec(text))) {
-      const target = match[1]
+      const target = match[1] || match[2]
       if (nodes.find(nn => nn.id === target)) {
         const id = `${n.id}->${target}`
         if (!unique.has(id)) {
@@ -134,7 +134,8 @@ export default function App() {
   }
 
   const onTextChange = e => {
-    const value = e.target.value
+    let value = e.target.value
+    value = value.replace(/(^|[^[])#(\d{3})(?!\])/g, (_, p1, p2) => `${p1}[#${p2}]`)
     setText(value)
     setNodes(ns => {
       const updated = ns.map(n =>


### PR DESCRIPTION
## Summary
- support bare node references like `#003`
- auto-convert `#NNN` patterns in editor
- document easier linking syntax

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418856df74832fb5e15e44171290af