### PR TITLE
Add minimap overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ npm run build
 ```
 
 Project files can be saved and loaded using the buttons in the interface. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
+
+The graph view now provides zoom controls and a minimap for easier navigation of large node collections.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import ReactFlow, {
   applyEdgeChanges,
   Background,
   MarkerType,
+  MiniMap,
+  Controls,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
 import './App.css'
@@ -233,13 +235,15 @@ export default function App() {
             onEdgesChange={onEdgesChange}
             onConnect={onConnect}
             onNodeClick={onNodeClick}
-            onPaneClick={onPaneClick}
-            nodeTypes={nodeTypes}
-            fitView
-          >
-            <Background color="#374151" variant="dots" gap={16} size={1} />
-          </ReactFlow>
-        </div>
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          fitView
+        >
+          <Background color="#374151" variant="dots" gap={16} size={1} />
+          <MiniMap zoomable pannable />
+          <Controls />
+        </ReactFlow>
+      </div>
         <section id="editor">
           <h2 id="nodeId">#{currentId || '000'} {title}</h2>
           <input id="title" value={title} onChange={onTitleChange} placeholder="Title" />

--- a/src/index.css
+++ b/src/index.css
@@ -123,3 +123,15 @@ main {
   font-size: 0.8rem;
   opacity: 0.7;
 }
+
+/* React Flow UI elements */
+.react-flow__controls button {
+  background: #1f2937;
+  color: #f9fafb;
+  border: 1px solid #374151;
+}
+
+.react-flow__minimap {
+  background: #161b22;
+  border: 1px solid #374151;
+}


### PR DESCRIPTION
## Summary
- support MiniMap and Controls from React Flow
- style the minimap and controls
- document the new navigation features

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_684189da9aa0832fae72bbf99963a29f