### PR TITLE
Add markdown formatting buttons

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,21 @@ main {
   font-size: 1rem;
 }
 
+#formatting-toolbar {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-bottom: 1px solid #374151;
+  background: #161b22;
+}
+
+#formatting-toolbar button {
+  background: #0d1117;
+  color: #f9fafb;
+  border: 1px solid #374151;
+  cursor: pointer;
+}
+
 #text {
   flex: 1;
   width: 100%;


### PR DESCRIPTION
## Summary
- add buttons for bold, italic, underline, and headings in the editor
- wrap selection in markdown tokens or add heading prefixes
- style the new formatting toolbar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68418b90a240832f82ed1323b4815dc2