### PR TITLE
Add interactive playthrough mode

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import ReactFlow, {
 import 'reactflow/dist/style.css'
 import './App.css'
 import NodeCard from './NodeCard.jsx'
+import Playthrough from './Playthrough.jsx'
 import pkg from '../package.json'
 
 function scanEdges(nodes) {
@@ -47,6 +48,7 @@ export default function App() {
   const [text, setText] = useState('')
   const [title, setTitle] = useState('')
   const [showModal, setShowModal] = useState(false)
+  const [showPlay, setShowPlay] = useState(false)
   const textRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
 
@@ -379,6 +381,7 @@ export default function App() {
         <button onClick={save}>Save</button>
         <input type="file" onChange={load} />
         <button onClick={() => setShowModal(s => !s)}>Linear View</button>
+        <button onClick={() => setShowPlay(true)}>Playthrough</button>
         <div id="version">v{pkg.version}</div>
       </header>
       <main>
@@ -425,6 +428,13 @@ export default function App() {
           </button>
           <pre id="modalList">{linearList()}</pre>
         </div>
+      )}
+      {showPlay && (
+        <Playthrough
+          nodes={nodes}
+          startId={currentId || undefined}
+          onClose={() => setShowPlay(false)}
+        />
       )}
     </>
   )

--- a/src/Playthrough.jsx
+++ b/src/Playthrough.jsx
@@ -1,0 +1,50 @@
+import { useState, useMemo } from 'react'
+import { marked } from 'marked'
+
+function renderHtml(text = '') {
+  let html = marked.parse(text)
+  html = html.replace(/\[#(\d{3})]|#(\d{3})/g, (_m, p1, p2) => {
+    const id = p1 || p2
+    return `<button type="button" class="choice" data-id="${id}">#${id}</button>`
+  })
+  return html
+}
+
+export default function Playthrough({ nodes, startId, onClose }) {
+  const nodeMap = useMemo(() => new Map(nodes.map(n => [n.id, n])), [nodes])
+  const firstId = useMemo(() => {
+    if (startId) return startId
+    const ids = Array.from(nodeMap.keys()).sort()
+    return ids[0] || null
+  }, [nodeMap, startId])
+  const [currentId, setCurrentId] = useState(firstId)
+
+  const node = nodeMap.get(currentId)
+  const html = useMemo(() => renderHtml(node?.data.text || ''), [node])
+  if (!currentId || !node) return null
+
+  const onClick = e => {
+    const btn = e.target.closest('button.choice')
+    if (btn?.dataset.id) {
+      setCurrentId(btn.dataset.id)
+    }
+  }
+
+  return (
+    <div id="playthrough" role="dialog" aria-modal="true" className="show">
+      <button
+        id="closePlay"
+        aria-label="Close playthrough"
+        onClick={onClose}
+      >
+        Close
+      </button>
+      <h2 id="playId">#{node.id} {node.data.title}</h2>
+      <div
+        className="play-text"
+        onClick={onClick}
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -161,3 +161,33 @@ main {
   background: #161b22;
   border: 1px solid #374151;
 }
+
+#playthrough {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.8);
+  color: #fff;
+  display: none;
+  flex-direction: column;
+  padding: 0.5rem;
+}
+
+#playthrough.show {
+  display: flex;
+}
+
+#playthrough .play-text {
+  flex: 1;
+  overflow-y: auto;
+}
+
+#playthrough .choice {
+  background: #1f2937;
+  color: #f9fafb;
+  border: 1px solid #374151;
+  margin: 0 0.25rem;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- create `Playthrough` component for step‑by‑step reading
- expose Playthrough via new button in the header
- store playthrough state in App
- add overlay styles for the playthrough view

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684190287ed8832fb29b9e255098768c