### PR TITLE
Add auto save and import/export

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,6 @@ npm run dev
 npm run build
 ```
 
-Project files can be saved and loaded using the buttons in the interface. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
+Project data is automatically saved to your browser's `localStorage` and restored on reload. Use the **Export** and **Import** buttons to download or load `.json` files manually. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
 
 The graph view now provides zoom controls and a minimap for easier navigation of large node collections.


### PR DESCRIPTION
## Summary
- automatically store story data in localStorage
- restore previous session on startup
- add Export and Import buttons in the UI
- document auto save behaviour

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684196807978832fbb86758a83a72b4a