### PR TITLE
Update lucide-react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "valj-vag-verktyg",
       "version": "0.0.1",
       "dependencies": {
-        "lucide-react": "^0.379.0",
+        "lucide-react": "^0.513.0",
         "marked": "^15.0.12",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -1731,7 +1731,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -1989,7 +1989,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-color": {
@@ -2711,12 +2711,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.379.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.379.0.tgz",
-      "integrity": "sha512-KcdeVPqmhRldldAAgptb8FjIunM2x2Zy26ZBh1RsEUcdLIvsEmbcw7KpzFYUy5BbpGeWhPu9Z9J5YXfStiXwhg==",
+      "version": "0.513.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.513.0.tgz",
+      "integrity": "sha512-CJZKq2g8Y8yN4Aq002GahSXbG2JpFv9kXwyiOAMvUBv7pxeOFHUWKB0mO7MiY4ZVFCV4aNjv2BJFq/z3DgKPQg==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/marked": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.1.0",
     "reactflow": "^11.11.4",
     "marked": "^15.0.12",
-    "lucide-react": "^0.379.0"
+    "lucide-react": "^0.513.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",


### PR DESCRIPTION
## Summary
- bump `lucide-react` to v0.513.0
- regenerate lockfile

## Testing
- `npm run dev`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68419e92652c832f92c7ce5f790cb106