### PR TITLE
Add node resizing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,6 +77,8 @@ export default function App() {
           type: 'card',
           position: n.position || { x: 0, y: 0 },
           data: { text: n.text || '', title: n.title || '' },
+          width: n.width,
+          height: n.height,
         }))
         setNodes(loaded)
         setEdges(scanEdges(loaded))
@@ -427,6 +429,8 @@ export default function App() {
         title: n.data.title || '',
         position: n.position,
         type: n.type || 'card',
+        width: n.width,
+        height: n.height,
       })),
     }
     const blob = new Blob([JSON.stringify(data, null, 2)], {
@@ -454,6 +458,8 @@ export default function App() {
         type: 'card',
         position: n.position || { x: 0, y: 0 },
         data: { text: n.text || '', title: n.title || '' },
+        width: n.width,
+        height: n.height,
       }))
       setNodes(loaded)
       setEdges(scanEdges(loaded))
@@ -495,6 +501,8 @@ export default function App() {
         title: n.data.title || '',
         position: n.position,
         type: n.type || 'card',
+        width: n.width,
+        height: n.height,
       })),
     }
     localStorage.setItem('cyoa-data', JSON.stringify(data))

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,16 +1,39 @@
-import { memo } from 'react'
-import { Handle, Position } from 'reactflow'
+import { memo, useState } from 'react'
+import { Handle, Position, useReactFlow } from 'reactflow'
+import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
+import '@reactflow/node-resizer/dist/style.css'
 import { parseText } from './parseText.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { snippet } = parseText(data.text)
+  const { setNodes } = useReactFlow()
+  const [resizing, setResizing] = useState(false)
+
+  const handleResizeEnd = (_e, { width, height }) => {
+    setResizing(false)
+    setNodes(ns =>
+      ns.map(n => (n.id === id ? { ...n, width, height } : n))
+    )
+  }
+
   return (
-    <div className={`node-card${selected ? ' selected' : ''}`}>
+    <div className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}>
       <div className="node-header">
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}
       </div>
       {snippet && <div className="node-preview">{snippet}</div>}
+      <NodeResizeControl
+        variant={ResizeControlVariant.Handle}
+        position="bottom-right"
+        minWidth={180}
+        minHeight={100}
+        maxWidth={400}
+        maxHeight={300}
+        className="resize-handle"
+        onResizeStart={() => setResizing(true)}
+        onResizeEnd={handleResizeEnd}
+      />
       <Handle type="source" position={Position.Right} />
       <Handle type="target" position={Position.Left} />
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import './theme.css';
+@import '@reactflow/node-resizer/dist/style.css';
 
 html,
 body {
@@ -155,7 +156,6 @@ main {
 
 .node-card {
   width: 220px;
-  max-width: 220px;
   background: var(--card);
   color: var(--text);
   border: 1px solid var(--panel);
@@ -163,12 +163,20 @@ main {
   box-shadow: 0 2px 6px #0005;
   padding: 0.75rem;
   font-size: 0.8rem;
+  min-width: 180px;
+  min-height: 100px;
+  max-width: 400px;
+  max-height: 300px;
+  position: relative;
 }
 .node-card:hover {
   border-color: var(--accent);
 }
 .node-card.selected {
   background: #3b4553;
+}
+.node-card.resizing {
+  border-style: dashed;
 }
 .node-card .node-id {
   font-family: monospace;
@@ -196,6 +204,18 @@ main {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.resize-handle {
+  position: absolute;
+  right: 4px;
+  bottom: 4px;
+  width: 12px;
+  height: 12px;
+  cursor: nwse-resize;
+  background: var(--accent);
+  border-radius: 2px;
+  opacity: 0.5;
 }
 
 #version {


### PR DESCRIPTION
## Summary
- make nodes resizable by adding `NodeResizeControl`
- style resize handle and show dashed border while resizing
- persist width and height on save/load

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841a1047074832f86894705de307627