### PR TITLE
Fix node size sync and text wrapping

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -77,8 +77,8 @@ export default function App() {
           type: 'card',
           position: n.position || { x: 0, y: 0 },
           data: { text: n.text || '', title: n.title || '' },
-          width: n.width,
-          height: n.height,
+          width: n.width ?? 220,
+          height: n.height ?? 100,
         }))
         setNodes(loaded)
         setEdges(scanEdges(loaded))
@@ -355,7 +355,14 @@ export default function App() {
       }
       const updated = [
         ...updatedNodes,
-        { id, position, type: 'card', data: { text: '', title: '' } },
+        {
+          id,
+          position,
+          type: 'card',
+          data: { text: '', title: '' },
+          width: 220,
+          height: 100,
+        },
       ]
       setEdges(scanEdges(updated))
       return updated
@@ -458,8 +465,8 @@ export default function App() {
         type: 'card',
         position: n.position || { x: 0, y: 0 },
         data: { text: n.text || '', title: n.title || '' },
-        width: n.width,
-        height: n.height,
+        width: n.width ?? 220,
+        height: n.height ?? 100,
       }))
       setNodes(loaded)
       setEdges(scanEdges(loaded))

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -2,10 +2,8 @@ import { memo, useState } from 'react'
 import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
-import { parseText } from './parseText.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
-  const { snippet } = parseText(data.text)
   const { setNodes } = useReactFlow()
   const [resizing, setResizing] = useState(false)
 
@@ -22,7 +20,7 @@ const NodeCard = memo(({ id, data, selected }) => {
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}
       </div>
-      {snippet && <div className="node-preview">{snippet}</div>}
+      {data.text && <div className="node-preview">{data.text}</div>}
       <NodeResizeControl
         variant={ResizeControlVariant.Handle}
         position="bottom-right"

--- a/src/index.css
+++ b/src/index.css
@@ -155,7 +155,8 @@ main {
 }
 
 .node-card {
-  width: 220px;
+  width: 100%;
+  height: 100%;
   background: var(--card);
   color: var(--text);
   border: 1px solid var(--panel);
@@ -168,6 +169,8 @@ main {
   max-width: 400px;
   max-height: 300px;
   position: relative;
+  display: flex;
+  flex-direction: column;
 }
 .node-card:hover {
   border-color: var(--accent);
@@ -200,10 +203,10 @@ main {
 }
 .node-card .node-preview {
   color: var(--text-dim);
-  max-height: 4em;
+  flex: 1;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .resize-handle {


### PR DESCRIPTION
## Summary
- sync resized node dimensions to board display
- ensure node text wraps like in the editor
- default node width and height when none exist

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a4bb7474832f91d8e91a9e8e88e9