### PR TITLE
Improve linear view UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ import 'reactflow/dist/style.css'
 import './App.css'
 import NodeCard from './NodeCard.jsx'
 import Playthrough from './Playthrough.jsx'
+import LinearView from './LinearView.jsx'
 import Button from './Button.jsx'
 import pkg from '../package.json'
 
@@ -540,12 +541,6 @@ export default function App() {
     localStorage.setItem('cyoa-data', JSON.stringify(data))
   }, [nodes, nextId])
 
-  const linearList = () =>
-    nodes
-      .slice()
-      .sort((a, b) => Number(a.id) - Number(b.id))
-      .map(n => `--- Node #${n.id} ${n.data.title || ''} ---\n${n.data.text || ''}`)
-      .join('\n\n')
 
   return (
     <>
@@ -623,12 +618,7 @@ export default function App() {
         </section>
       </main>
       {showModal && (
-        <div id="modal" role="dialog" aria-modal="true" className="show">
-          <button className="btn ghost" id="closeModal" aria-label="Close linear view" onClick={() => setShowModal(false)}>
-            Close
-          </button>
-          <pre id="modalList">{linearList()}</pre>
-        </div>
+        <LinearView nodes={nodes} onClose={() => setShowModal(false)} />
       )}
       {showPlay && (
         <Playthrough

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,0 +1,32 @@
+import { useMemo } from 'react'
+import { marked } from 'marked'
+
+function renderHtml(nodes = []) {
+  const html = nodes
+    .slice()
+    .sort((a, b) => Number(a.id) - Number(b.id))
+    .map(n => {
+      const title = n.data.title ? ` ${n.data.title}` : ''
+      const heading = `<h2 id="${n.id}">#${n.id}${title}</h2>`
+      let body = marked.parse(n.data.text || '')
+      body = body.replace(/\[#(\d{3})]|#(\d{3})/g, (_m, p1, p2) => {
+        const id = p1 || p2
+        return `<a href="#${id}">#${id}</a>`
+      })
+      return `${heading}\n${body}`
+    })
+    .join('\n')
+  return html
+}
+
+export default function LinearView({ nodes, onClose }) {
+  const html = useMemo(() => renderHtml(nodes), [nodes])
+  return (
+    <div id="modal" role="dialog" aria-modal="true" className="show">
+      <button className="btn ghost" id="closeModal" aria-label="Close linear view" onClick={onClose}>
+        Close
+      </button>
+      <div id="modalList" dangerouslySetInnerHTML={{ __html: html }} />
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -135,8 +135,8 @@ main {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: rgba(0, 0, 0, 0.8);
-  color: var(--text);
+  background: #121212;
+  color: #f0f0f0;
   display: none;
   flex-direction: column;
 }
@@ -152,10 +152,20 @@ main {
 
 #modalList {
   flex: 1;
-  overflow: auto;
-  padding: 0.5rem;
-  white-space: pre-wrap;
+  overflow-y: auto;
+  padding: 1rem;
+  max-width: 800px;
+  margin: auto;
+  line-height: 1.6;
+  font-family: system-ui, sans-serif;
   user-select: text;
+}
+#modalList a {
+  color: #70b8ff;
+}
+#modalList h2 {
+  font-size: 1.4rem;
+  margin-top: 2rem;
 }
 
 .node-card {


### PR DESCRIPTION
## Summary
- add dedicated `LinearView` component to render all nodes as Markdown
- style linear view with centered layout and dark colors
- update app to use the new component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841a9bda40c832f84ecb27814a05452