### PR TITLE
Enhance LinearView editing

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,15 @@ main {
   background: var(--panel);
 }
 
+#linear-toolbar {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-bottom: 1px solid var(--panel);
+  background: var(--panel);
+  margin: 0 var(--gap);
+}
+
 #text {
   flex: 1;
   width: 100%;


### PR DESCRIPTION
## Summary
- add a formatting toolbar to the Linear View
- allow rich text actions on selected node

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b26d156c832f98df2e156e4bfe46