### PR TITLE
Improve Linear View markdown editing

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -17,7 +17,7 @@ export default function LinearView({ nodes = [], updateNodeText, onClose }) {
   )
 
   const activeId = useRef(null)
-  const textAreas = useRef({})
+  const editors = useRef({})
 
   const onChange = (id, e) => {
     let value = e.target.value
@@ -28,7 +28,7 @@ export default function LinearView({ nodes = [], updateNodeText, onClose }) {
   const wrapSelected = (before, after = before) => {
     const id = activeId.current
     if (!id) return
-    const area = textAreas.current[id]
+    const area = editors.current[id]
     if (!area) return
     const start = area.selectionStart
     const end = area.selectionEnd
@@ -46,7 +46,7 @@ export default function LinearView({ nodes = [], updateNodeText, onClose }) {
   const applyHeading = level => {
     const id = activeId.current
     if (!id) return
-    const area = textAreas.current[id]
+    const area = editors.current[id]
     if (!area) return
     const start = area.selectionStart
     const end = area.selectionEnd
@@ -87,17 +87,19 @@ export default function LinearView({ nodes = [], updateNodeText, onClose }) {
               <span className="node-id">#{n.id}</span>
               {n.data.title && <span className="node-title">{n.data.title}</span>}
             </h2>
-            <textarea
-              className="linear-edit"
-              ref={el => (textAreas.current[n.id] = el)}
-              onFocus={() => (activeId.current = n.id)}
-              value={n.data.text}
-              onChange={e => onChange(n.id, e)}
-            />
-            <div
-              className="linear-preview"
-              dangerouslySetInnerHTML={{ __html: parseHtml(n.data.text) }}
-            />
+            <div className="linear-editor">
+              <div
+                className="linear-render"
+                dangerouslySetInnerHTML={{ __html: parseHtml(n.data.text) }}
+              />
+              <textarea
+                className="linear-input"
+                ref={el => (editors.current[n.id] = el)}
+                onFocus={() => (activeId.current = n.id)}
+                value={n.data.text}
+                onChange={e => onChange(n.id, e)}
+              />
+            </div>
           </article>
         ))}
       </div>

--- a/src/index.css
+++ b/src/index.css
@@ -194,17 +194,36 @@ main {
   font-weight: 600;
   color: #fff;
 }
-#modalList .linear-edit {
+#modalList .linear-editor {
+  position: relative;
   width: 100%;
-  background: var(--panel);
-  color: var(--text);
   border: 1px solid var(--panel);
-  padding: 0.25rem 0.5rem;
-  font-family: ui-monospace, SFMono-Regular;
+  background: var(--panel);
   margin-bottom: 0.5rem;
+  font-family: ui-monospace, SFMono-Regular;
 }
-#modalList .linear-preview {
+#modalList .linear-editor .linear-render {
+  white-space: pre-wrap;
   line-height: 1.6;
+  padding: 0.25rem 0.5rem;
+  color: var(--text);
+}
+#modalList .linear-editor .linear-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  resize: none;
+  background: transparent;
+  color: transparent;
+  caret-color: var(--text);
+  border: none;
+  padding: 0.25rem 0.5rem;
+  font-family: inherit;
+  line-height: 1.6;
+}
+#modalList .linear-editor .linear-input:focus {
+  outline: none;
 }
 
 .node-card {


### PR DESCRIPTION
## Summary
- rework LinearView to show a single markdown editor per node
- overlay textarea with markdown render so editing feels seamless
- add styles for new linear editor view

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841b447eb94832f9a8e4465bb783ab1