### PR TITLE
Add linear editor with parser

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -60,6 +60,7 @@ export default function App() {
   const [currentId, setCurrentId] = useState(null)
   const [text, setText] = useState('')
   const [title, setTitle] = useState('')
+  const [linearText, setLinearText] = useState('')
   const [showModal, setShowModal] = useState(false)
   const [showPlay, setShowPlay] = useState(false)
   const textRef = useRef(null)
@@ -571,6 +572,10 @@ export default function App() {
     return () => window.removeEventListener('keydown', handler)
   }, [undo, redo])
 
+  useEffect(() => {
+    setEdges(scanEdges(nodes))
+  }, [nodes])
+
   // Persist data after every change
   useEffect(() => {
     const data = {
@@ -619,7 +624,19 @@ export default function App() {
           onChange={importProject}
           style={{ display: 'none' }}
         />
-        <Button variant="ghost" icon={List} onClick={() => setShowModal(s => !s)}>
+        <Button
+          variant="ghost"
+          icon={List}
+          onClick={() => {
+            const md = nodes
+              .slice()
+              .sort((a, b) => Number(a.id) - Number(b.id))
+              .map(n => `#${n.id} ${n.data.title}\n${n.data.text}`)
+              .join('\n')
+            setLinearText(md)
+            setShowModal(true)
+          }}
+        >
           Linear View
         </Button>
         <Button variant="ghost" icon={Play} onClick={() => setShowPlay(true)}>
@@ -666,8 +683,9 @@ export default function App() {
       </main>
       {showModal && (
         <LinearView
-          nodes={nodes}
-          updateNodeText={updateNodeText}
+          text={linearText}
+          setText={setLinearText}
+          setNodes={setNodes}
           onClose={() => setShowModal(false)}
         />
       )}

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,52 +1,21 @@
-import { useMemo, useRef } from 'react'
-import Markdown, { parseHtml } from './Markdown.jsx'
+import { useEffect, useRef } from 'react'
+import useLinearParser from './useLinearParser.js'
 
-export default function LinearView({ nodes = [], updateNodeText, onClose }) {
-  const sorted = useMemo(
-    () => nodes.slice().sort((a, b) => Number(a.id) - Number(b.id)),
-    [nodes]
-  )
+export default function LinearView({ text, setText, setNodes, onClose }) {
+  const editorRef = useRef(null)
 
-  const activeId = useRef(null)
-  const editors = useRef({})
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.innerText = text || ''
+    }
+  }, [text])
 
-  const onBlur = (id, e) => {
-    let value = e.target.innerText
-    value = value.replace(/(^|[^[])#(\d{3})(?!\])/g, (_, p1, p2) => `${p1}[#${p2}]`)
-    updateNodeText(id, value)
-  }
+  useLinearParser(text, setNodes)
 
-  const wrapSelected = (before, after = before) => {
-    const id = activeId.current
-    if (!id) return
-    const el = editors.current[id]
-    if (!el) return
-    const sel = window.getSelection()
-    if (!sel?.rangeCount) return
-    const range = sel.getRangeAt(0)
-    if (!el.contains(range.startContainer)) return
-    const text = sel.toString()
-    range.deleteContents()
-    range.insertNode(document.createTextNode(before + text + after))
-    sel.collapseToEnd()
-    updateNodeText(id, el.innerText)
-  }
-
-  const applyHeading = level => {
-    const id = activeId.current
-    if (!id) return
-    const el = editors.current[id]
-    if (!el) return
-    const sel = window.getSelection()
-    if (!sel?.rangeCount) return
-    const range = sel.getRangeAt(0)
-    if (!el.contains(range.startContainer)) return
-    const text = sel.toString()
-    const prefix = '#'.repeat(level) + ' '
-    range.deleteContents()
-    range.insertNode(document.createTextNode(prefix + text))
-    sel.collapseToEnd()
-    updateNodeText(id, el.innerText)
+  const onInput = () => {
+    if (editorRef.current) {
+      setText(editorRef.current.innerText)
+    }
   }
 
   return (
@@ -59,36 +28,13 @@ export default function LinearView({ nodes = [], updateNodeText, onClose }) {
       >
         Close
       </button>
-      <div id="linear-toolbar">
-        <button className="btn ghost" type="button" onClick={() => wrapSelected('**')}>B</button>
-        <button className="btn ghost" type="button" onClick={() => wrapSelected('*')}>I</button>
-        <button className="btn ghost" type="button" onClick={() => wrapSelected('__')}>U</button>
-        <button className="btn ghost" type="button" onClick={() => applyHeading(1)}>H1</button>
-        <button className="btn ghost" type="button" onClick={() => applyHeading(2)}>H2</button>
-      </div>
-      <div id="modalList">
-        {sorted.map(n => (
-          <article
-            key={n.id}
-            data-id={n.id}
-            className="linear-node"
-          >
-            <p className="linear-meta" contentEditable={false}>
-              <span className="linear-id">#{n.id}</span>{' '}
-              <strong className="linear-title">{n.data.title}</strong>
-            </p>
-            <div
-              className="linear-body"
-              contentEditable
-              suppressContentEditableWarning
-              ref={el => (editors.current[n.id] = el)}
-              onFocus={() => (activeId.current = n.id)}
-              onBlur={e => onBlur(n.id, e)}
-              dangerouslySetInnerHTML={{ __html: parseHtml(n.data.text) }}
-            />
-          </article>
-        ))}
-      </div>
+      <div
+        id="linearEditor"
+        contentEditable
+        suppressContentEditableWarning
+        ref={editorRef}
+        onInput={onInput}
+      />
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -334,3 +334,36 @@ main {
 #playthrough .choice:hover {
   background: #5b667a;
 }
+
+#linearEditor {
+  font: 16px/1.5 'Inter', sans-serif;
+  max-width: 720px;
+  margin: auto;
+  flex: 1;
+  padding: 1rem;
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.linear-id {
+  font: 11px/1 monospace;
+  color: #777;
+}
+
+#linearEditor h3 {
+  font-size: 20px;
+  margin: 2.5rem 0 .25rem;
+}
+
+#linearEditor p {
+  margin: .75rem 0;
+}
+
+.node-link {
+  color: #2fa8ff;
+  text-decoration: none;
+}
+
+.node-link:hover {
+  text-decoration: underline;
+}

--- a/src/useLinearParser.js
+++ b/src/useLinearParser.js
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+
+export default function useLinearParser(raw = '', setNodes) {
+  useEffect(() => {
+    if (typeof setNodes !== 'function') return
+    const blocks = raw.split(/\n(?=#\d{3}\s)/)
+    const parsed = blocks
+      .map(block => {
+        const [first, ...rest] = block.split('\n')
+        const match = first.match(/^#(\d{3})\s+(.*)$/)
+        if (!match) return null
+        const [, id, title] = match
+        return { id, title, text: rest.join('\n').trim() }
+      })
+      .filter(Boolean)
+    setNodes(ns => {
+      const map = new Map(ns.map(n => [n.id, n]))
+      const updated = parsed.map((p, i) => {
+        const existing = map.get(p.id)
+        if (existing) {
+          return { ...existing, data: { ...existing.data, text: p.text, title: p.title } }
+        }
+        return {
+          id: p.id,
+          type: 'card',
+          position: { x: 0, y: i * 100 },
+          data: { text: p.text, title: p.title },
+          width: 220,
+          height: 100,
+        }
+      })
+      return updated
+    })
+  }, [raw, setNodes])
+}


### PR DESCRIPTION
## Summary
- implement `useLinearParser` hook for parsing linear markdown into nodes
- refactor `LinearView` to use single contenteditable editor
- integrate linear view with new parser in `App`
- style linear editor

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841be6707e0832f996e93812cbf4752