### PR TITLE
Implement AI suggestion system

### DIFF
--- a/src/AiSettingsModal.jsx
+++ b/src/AiSettingsModal.jsx
@@ -1,0 +1,93 @@
+import { useState } from 'react'
+import Button from './Button.jsx'
+
+export default function AiSettingsModal({ settings, onChange, onClose }) {
+  const [local, setLocal] = useState(settings)
+
+  const update = updates => {
+    const next = { ...local, ...updates }
+    setLocal(next)
+  }
+
+  const save = () => {
+    onChange(local)
+    onClose()
+  }
+
+  return (
+    <div id="modal" role="dialog" aria-modal="true" className="show">
+      <button
+        id="closeModal"
+        className="btn ghost"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        Close
+      </button>
+      <div id="modalList">
+        <h3>AI Settings</h3>
+        <label>
+          <input
+            type="checkbox"
+            checked={local.enabled}
+            onChange={e => update({ enabled: e.target.checked })}
+          />
+          Enable AI features
+        </label>
+        <div>
+          <label>API Key</label>
+          <input
+            type="password"
+            value={local.apiKey}
+            placeholder="sk-XXXX-YOUR-KEY-HERE"
+            onChange={e => update({ apiKey: e.target.value })}
+          />
+        </div>
+        <div>
+          <label>Model</label>
+          <select
+            value={local.model}
+            onChange={e => update({ model: e.target.value })}
+          >
+            <option value="gpt-3.5-turbo">gpt-3.5-turbo</option>
+            <option value="gpt-4">gpt-4</option>
+          </select>
+        </div>
+        <div>
+          <label>Context depth</label>
+          <input
+            type="number"
+            min="1"
+            max="5"
+            value={local.contextDepth}
+            onChange={e => update({ contextDepth: Number(e.target.value) })}
+          />
+        </div>
+        <div>
+          <label>Max tokens</label>
+          <input
+            type="number"
+            min="10"
+            max="500"
+            value={local.maxTokens}
+            onChange={e => update({ maxTokens: Number(e.target.value) })}
+          />
+        </div>
+        <div>
+          <label>Temperature</label>
+          <input
+            type="number"
+            step="0.1"
+            min="0"
+            max="1"
+            value={local.temperature}
+            onChange={e => update({ temperature: Number(e.target.value) })}
+          />
+        </div>
+        <Button variant="primary" onClick={save}>
+          Save
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/AiSuggestionsPanel.jsx
+++ b/src/AiSuggestionsPanel.jsx
@@ -1,0 +1,29 @@
+import Button from './Button.jsx'
+
+export default function AiSuggestionsPanel({ suggestions = [], onPick, onClose }) {
+  return (
+    <div id="modal" role="dialog" aria-modal="true" className="show">
+      <button
+        id="closeModal"
+        className="btn ghost"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        Close
+      </button>
+      <div id="modalList">
+        <h3>AI Suggestions</h3>
+        {suggestions.length === 0 && <p>No suggestions</p>}
+        <ul>
+          {suggestions.map((s, i) => (
+            <li key={i}>
+              <Button variant="ghost" onClick={() => onPick(s)}>
+                {s}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  )
+}

--- a/src/useAi.js
+++ b/src/useAi.js
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react'
+
+const STORAGE_KEY = 'ai-settings'
+
+const defaultSettings = {
+  enabled: false,
+  apiKey: '',
+  model: 'gpt-3.5-turbo',
+  contextDepth: 3,
+  maxTokens: 60,
+  temperature: 0.7,
+}
+
+export function useAiSettings() {
+  const [settings, setSettings] = useState(() => {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (saved) {
+      try {
+        return { ...defaultSettings, ...JSON.parse(saved) }
+      } catch {
+        /* ignore */
+      }
+    }
+    return defaultSettings
+  })
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+  }, [settings])
+
+  return [settings, setSettings]
+}
+
+export async function getSuggestions(nodes, currentId, settings) {
+  if (!settings.enabled || !settings.apiKey) return []
+  const current = nodes.find(n => n.id === currentId)
+  if (!current) return []
+  const history = []
+  const ids = nodes
+    .map(n => Number(n.id))
+    .sort((a, b) => a - b)
+    .filter(id => id < Number(currentId))
+    .slice(-settings.contextDepth)
+  for (const id of ids) {
+    const node = nodes.find(n => n.id === id)
+    if (node) history.push(node)
+  }
+  const context = history
+    .map(n => `#${n.id} ${n.data.title || ''}\n${n.data.text || ''}`)
+    .join('\n\n')
+  const prompt = `Du hjälper till att skriva en interaktiv berättelse. Här är tidigare delar:\n\n${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.`
+
+  const body = {
+    model: settings.model,
+    messages: [{ role: 'user', content: prompt }],
+    max_tokens: settings.maxTokens,
+    temperature: settings.temperature,
+  }
+
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${settings.apiKey}`,
+    },
+    body: JSON.stringify(body),
+  })
+  if (!res.ok) return []
+  const data = await res.json()
+  const text = data.choices?.[0]?.message?.content || ''
+  return text
+    .split('\n')
+    .map(t => t.trim())
+    .filter(Boolean)
+}


### PR DESCRIPTION
## Summary
- add AI settings hook and API calls
- create AI settings modal for GPT parameters
- show suggestions from OpenAI and allow inserting into nodes
- wire up AI buttons in the editor

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841df63ca50832f8f1cf61533707902