### PR TITLE
Add AI loading indicator and custom prompt settings

### DIFF
--- a/src/AiSettingsModal.jsx
+++ b/src/AiSettingsModal.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import Button from './Button.jsx'
+import { defaultPrompt } from './useAi.js'
 
 export default function AiSettingsModal({ settings, onChange, onClose }) {
   const [local, setLocal] = useState(settings)
@@ -83,6 +84,21 @@ export default function AiSettingsModal({ settings, onChange, onClose }) {
             value={local.temperature}
             onChange={e => update({ temperature: Number(e.target.value) })}
           />
+        </div>
+        <div>
+          <label>Base prompt</label>
+          <textarea
+            value={local.customPrompt}
+            onChange={e => update({ customPrompt: e.target.value })}
+            rows="4"
+          />
+          <Button
+            className="reset-btn"
+            type="button"
+            onClick={() => update({ customPrompt: defaultPrompt })}
+          >
+            Reset to default
+          </Button>
         </div>
         <Button variant="primary" onClick={save}>
           Save

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -70,6 +70,7 @@ export default function App() {
   const [suggestions, setSuggestions] = useState([])
   const [showAiSettings, setShowAiSettings] = useState(false)
   const [showSuggestions, setShowSuggestions] = useState(false)
+  const [loadingAi, setLoadingAi] = useState(false)
   const textRef = useRef(null)
   const importRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
@@ -211,7 +212,9 @@ export default function App() {
   }
 
   const fetchAiSuggestions = async () => {
+    setLoadingAi(true)
     const result = await getSuggestions(nodes, currentId, aiSettings)
+    setLoadingAi(false)
     setSuggestions(result)
     setShowSuggestions(true)
   }
@@ -706,6 +709,9 @@ export default function App() {
           <button className="btn ghost" type="button" onClick={() => applyHeading(1)}>H1</button>
           <button className="btn ghost" type="button" onClick={() => applyHeading(2)}>H2</button>
           <button className="btn ghost" type="button" onClick={fetchAiSuggestions}>AI</button>
+          <span className={`ai-loading${loadingAi ? ' show' : ''}`} aria-live="polite">
+            Genererar förslag…
+          </span>
           <button className="btn ghost" type="button" onClick={() => setShowAiSettings(true)}>
             Settings
           </button>

--- a/src/index.css
+++ b/src/index.css
@@ -120,6 +120,22 @@ main {
   background: var(--panel);
 }
 
+.ai-loading {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
+  opacity: 0;
+  transition: opacity 0.3s;
+  align-self: center;
+}
+
+.ai-loading.show {
+  opacity: 1;
+}
+
+.reset-btn {
+  margin-left: 0.5rem;
+}
+
 #linear-toolbar {
   display: flex;
   gap: 0.25rem;

--- a/src/useAi.js
+++ b/src/useAi.js
@@ -2,6 +2,9 @@ import { useState, useEffect } from 'react'
 
 const STORAGE_KEY = 'ai-settings'
 
+export const defaultPrompt =
+  'Du skriver en interaktiv berättelse. Här är tidigare noder...\n\n'
+
 const defaultSettings = {
   enabled: false,
   apiKey: '',
@@ -9,6 +12,7 @@ const defaultSettings = {
   contextDepth: 3,
   maxTokens: 60,
   temperature: 0.7,
+  customPrompt: defaultPrompt,
 }
 
 export function useAiSettings() {
@@ -48,7 +52,7 @@ export async function getSuggestions(nodes, currentId, settings) {
   const context = history
     .map(n => `#${n.id} ${n.data.title || ''}\n${n.data.text || ''}`)
     .join('\n\n')
-  const prompt = `Du hjälper till att skriva en interaktiv berättelse. Här är tidigare delar:\n\n${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.`
+  const prompt = `${settings.customPrompt || defaultPrompt}${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.`
 
   const body = {
     model: settings.model,


### PR DESCRIPTION
## Summary
- show loading indicator while waiting for AI suggestions
- allow editing the base AI prompt in settings with a reset button
- store the custom prompt in local storage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6841e4a666e0832f95e0f50c7659e942