### PR TITLE
Display AI suggestions as bullet list blocks

### DIFF
--- a/src/AiSuggestionsPanel.jsx
+++ b/src/AiSuggestionsPanel.jsx
@@ -1,5 +1,3 @@
-import Button from './Button.jsx'
-
 export default function AiSuggestionsPanel({ suggestions = [], onPick, onClose }) {
   return (
     <div id="modal" role="dialog" aria-modal="true" className="show">
@@ -14,15 +12,11 @@ export default function AiSuggestionsPanel({ suggestions = [], onPick, onClose }
       <div id="modalList">
         <h3>AI Suggestions</h3>
         {suggestions.length === 0 && <p>No suggestions</p>}
-        <ul>
-          {suggestions.map((s, i) => (
-            <li key={i}>
-              <Button variant="ghost" onClick={() => onPick(s)}>
-                {s}
-              </Button>
-            </li>
-          ))}
-        </ul>
+        {suggestions.map((s, i) => (
+          <div key={i} className="suggestion" onClick={() => onPick(s)}>
+            {s}
+          </div>
+        ))}
       </div>
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -215,6 +215,20 @@ main {
   margin: 0.5rem 0;
 }
 
+.suggestion {
+  background: var(--card);
+  border: 1px solid var(--panel);
+  border-radius: var(--radius);
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  cursor: pointer;
+  white-space: pre-wrap;
+}
+
+.suggestion:hover {
+  background: var(--btn-hover);
+}
+
 .node-card {
   width: 100%;
   height: 100%;

--- a/src/useAi.js
+++ b/src/useAi.js
@@ -52,7 +52,7 @@ export async function getSuggestions(nodes, currentId, settings) {
   const context = history
     .map(n => `#${n.id} ${n.data.title || ''}\n${n.data.text || ''}`)
     .join('\n\n')
-  const prompt = `${settings.customPrompt || defaultPrompt}${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.`
+  const prompt = `${settings.customPrompt || defaultPrompt}${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.\nReturnera tre olika fortsättningar, börja varje med • och använd samma berättarstil som tidigare. Om du ger val, använd markdownlänkar som [#004].`
 
   const body = {
     model: settings.model,
@@ -73,7 +73,7 @@ export async function getSuggestions(nodes, currentId, settings) {
   const data = await res.json()
   const text = data.choices?.[0]?.message?.content || ''
   return text
-    .split('\n')
+    .split(/\n(?=\u2022)/)
     .map(t => t.trim())
     .filter(Boolean)
 }


### PR DESCRIPTION
## Summary
- show AI suggestions in blocks so bullet markers remain visible
- style `.suggestion` blocks
- instruct the AI to start each suggestion with `•`
- parse returned suggestions by bullet

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6841fac8d538832f913c6e976f138e2b