### PR TITLE
Add dagre auto-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@tiptap/extension-underline": "^2.13.0",
         "@tiptap/react": "^2.13.0",
         "@tiptap/starter-kit": "^2.13.0",
+        "dagre": "^0.8.5",
         "lucide-react": "^0.513.0",
         "marked": "^15.0.12",
         "react": "^19.1.0",
@@ -2566,6 +2567,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -2988,6 +2999,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3186,6 +3206,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tiptap/extension-underline": "^2.13.0",
     "@tiptap/react": "^2.13.0",
     "@tiptap/starter-kit": "^2.13.0",
+    "dagre": "^0.8.5",
     "lucide-react": "^0.513.0",
     "marked": "^15.0.12",
     "react": "^19.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -20,6 +20,7 @@ import ReactFlow, {
   MiniMap,
   Controls,
 } from 'reactflow'
+import getLayoutedElements from './dagreLayout'
 import 'reactflow/dist/style.css'
 import './App.css'
 import NodeCard from './NodeCard.jsx'
@@ -626,6 +627,17 @@ export default function App() {
     }
   }
 
+  const handleAutoLayout = useCallback(() => {
+    pushUndoState()
+    const { nodes: layouted, edges: layoutedEdges } = getLayoutedElements(
+      nodes,
+      edges,
+      'LR'
+    )
+    setNodes(layouted)
+    setEdges(layoutedEdges)
+  }, [nodes, edges, pushUndoState])
+
   useEffect(() => {
     const handler = e => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
@@ -680,6 +692,11 @@ export default function App() {
         <Button variant="ghost" icon={RotateCw} onClick={redo}>
           Redo
         </Button>
+        {!showModal && !showPlay && (
+          <Button variant="ghost" onClick={handleAutoLayout}>
+            Auto-layout
+          </Button>
+        )}
         <input
           id="projectName"
           value={projectName}

--- a/src/dagreLayout.ts
+++ b/src/dagreLayout.ts
@@ -1,0 +1,28 @@
+import dagre from 'dagre'
+import type { Edge, Node } from 'reactflow'
+
+export default function getLayoutedElements(nodes: Node[], edges: Edge[], direction = 'LR') {
+  const dagreGraph = new dagre.graphlib.Graph()
+  dagreGraph.setDefaultEdgeLabel(() => ({}))
+  dagreGraph.setGraph({ rankdir: direction })
+
+  nodes.forEach(node => {
+    const width = node.width ?? 250
+    const height = node.height ?? 100
+    dagreGraph.setNode(node.id, { width, height })
+  })
+
+  edges.forEach(edge => dagreGraph.setEdge(edge.source, edge.target))
+
+  dagre.layout(dagreGraph)
+
+  const layouted = nodes.map(node => {
+    const { x, y } = dagreGraph.node(node.id)
+    return {
+      ...node,
+      position: { x: x - (node.width ?? 250) / 2, y: y - (node.height ?? 100) / 2 },
+    }
+  })
+
+  return { nodes: layouted, edges }
+}


### PR DESCRIPTION
## Summary
- install dagre
- add `getLayoutedElements` helper for dagre layouts
- add `handleAutoLayout` and button in UI

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684210a0b5fc832fa0b543111fe5a7c8