### PR TITLE
Improve markdown security

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,6 @@ npm run build
 
 Project data is automatically saved to your browser's `localStorage` and restored on reload. Use the **Export** and **Import** buttons to download or load `.json` files manually. The **Export MD** button downloads a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
 
+All rendered Markdown is sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) to prevent unwanted HTML injection.
+
 The graph view now provides zoom controls and a minimap for easier navigation of large node collections.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "reactflow": "^11.11.4",
-    "tiptap-markdown": "^0.8.10"
+    "tiptap-markdown": "^0.8.10",
+    "dompurify": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/Markdown.jsx
+++ b/src/Markdown.jsx
@@ -1,4 +1,5 @@
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 export function parseHtml(text = '') {
   let html = marked.parse(text)
@@ -6,7 +7,7 @@ export function parseHtml(text = '') {
     const id = p1 || p2
     return `<a href="#${id}">#${id}</a>`
   })
-  return html
+  return DOMPurify.sanitize(html)
 }
 
 export default function Markdown({ children = '', className = '' }) {

--- a/src/Playthrough.jsx
+++ b/src/Playthrough.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from 'react'
 import { marked } from 'marked'
+import DOMPurify from 'dompurify'
 
 function renderHtml(text = '') {
   let html = marked.parse(text)
@@ -7,7 +8,7 @@ function renderHtml(text = '') {
     const id = p1 || p2
     return `<button type="button" class="choice" data-id="${id}">#${id}</button>`
   })
-  return html
+  return DOMPurify.sanitize(html)
 }
 
 export default function Playthrough({ nodes, startId, onClose }) {


### PR DESCRIPTION
## Summary
- sanitize user-provided markdown with DOMPurify
- include DOMPurify dependency
- mention sanitization in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421480534c832fbea2b80d2084e975