### PR TITLE
Enable editing text directly within nodes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ import getLayoutedElements from './dagreLayout'
 import 'reactflow/dist/style.css'
 import './App.css'
 import NodeCard from './NodeCard.jsx'
+import NodeEditorContext from './NodeEditorContext.js'
 import Playthrough from './Playthrough.jsx'
 import LinearView from './LinearView.jsx'
 import AiSettingsModal from './AiSettingsModal.jsx'
@@ -750,6 +751,7 @@ export default function App() {
       </header>
       <main style={{ position: 'relative' }}>
         <div id="graph">
+          <NodeEditorContext.Provider value={{ updateNodeText }}>
           <ReactFlow
             style={{ width: '100%', height: '100%' }}
             nodes={nodes}
@@ -773,6 +775,7 @@ export default function App() {
           <MiniMap zoomable pannable />
           <Controls />
         </ReactFlow>
+        </NodeEditorContext.Provider>
       </div>
         <button
           id="toggleEditor"

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,11 +1,18 @@
-import { memo, useState } from 'react'
+import { memo, useState, useContext, useEffect, useRef } from 'react'
 import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
+import NodeEditorContext from './NodeEditorContext.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { setNodes } = useReactFlow()
+  const { updateNodeText } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
+  const textRef = useRef(null)
+
+  useEffect(() => {
+    if (selected) textRef.current?.focus()
+  }, [selected])
 
   const handleResizeEnd = (_e, { width, height }) => {
     setResizing(false)
@@ -20,7 +27,22 @@ const NodeCard = memo(({ id, data, selected }) => {
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}
       </div>
-      {data.text && <div className="node-preview">{data.text}</div>}
+      {selected ? (
+        <textarea
+          ref={textRef}
+          className="node-textarea"
+          value={data.text}
+          onChange={e => {
+            let value = e.target.value
+            value = value.replace(/(^|[^[])#(\d{3})(?!\])/g, (_, p1, p2) => `${p1}[#${p2}]`)
+            if (updateNodeText) {
+              updateNodeText(id, value)
+            }
+          }}
+        />
+      ) : (
+        data.text && <div className="node-preview">{data.text}</div>
+      )}
       <NodeResizeControl
         variant={ResizeControlVariant.Handle}
         position="bottom-right"

--- a/src/NodeEditorContext.js
+++ b/src/NodeEditorContext.js
@@ -1,0 +1,5 @@
+import { createContext } from 'react'
+
+const NodeEditorContext = createContext({ updateNodeText: () => {} })
+
+export default NodeEditorContext

--- a/src/index.css
+++ b/src/index.css
@@ -313,6 +313,17 @@ main {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
+.node-card .node-textarea {
+  flex: 1;
+  width: 100%;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular;
+  resize: none;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
 
 .resize-handle {
   position: absolute;


### PR DESCRIPTION
## Summary
- add `NodeEditorContext` to share `updateNodeText`
- make `NodeCard` editable when selected
- apply context provider in `App`
- style textarea used for node editing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68429c7199a4832fb747f6b58d96ce3b