### PR TITLE
Add autosave and project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm run dev
 npm run build
 ```
 
-Project data is automatically saved to your browser's `localStorage` and restored on reload. Use the **Export** and **Import** buttons to download or load `.json` files manually. The **Export MD** button downloads a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
+Project data can be saved locally. Tick the **Save** checkbox next to the project name to autosave the current story. Saved stories appear in the dropdown list in the header so you can quickly switch between them. The **Export** and **Import** buttons let you download or load `.json` files. The exported file now also contains the project name. The **Export MD** button downloads a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
 
 All rendered Markdown is sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) to prevent unwanted HTML injection.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -80,6 +80,21 @@ export default function App() {
   const [showModal, setShowModal] = useState(false)
   const [projectName, setProjectName] = useState('')
   const [showPlay, setShowPlay] = useState(false)
+  const [projects, setProjects] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('cyoa-projects')) || {}
+    } catch {
+      return {}
+    }
+  })
+  const [projectId, setProjectId] = useState(() =>
+    localStorage.getItem('cyoa-current') || String(Date.now())
+  )
+  const [projectStart, setProjectStart] = useState(Date.now())
+  const [autoSave, setAutoSave] = useState(() => {
+    const saved = localStorage.getItem('cyoa-auto-save')
+    return saved ? JSON.parse(saved) : false
+  })
   const [aiSettings, setAiSettings] = useAiSettings()
   const [suggestions, setSuggestions] = useState([])
   const [showAiSettings, setShowAiSettings] = useState(false)
@@ -94,10 +109,33 @@ export default function App() {
 
   // Restore previous session from localStorage on initial load
   useEffect(() => {
-    const saved = localStorage.getItem('cyoa-data')
-    if (saved) {
+    let projs = {}
+    try {
+      projs = JSON.parse(localStorage.getItem('cyoa-projects')) || {}
+    } catch {
+      /* ignore */
+    }
+    setProjects(projs)
+    const current = localStorage.getItem('cyoa-current')
+    const id = current || Object.keys(projs)[0] || String(Date.now())
+    setProjectId(id)
+    let data
+    if (projs[id]) {
+      data = projs[id].data
+      setProjectStart(projs[id].start || Date.now())
+    } else {
+      const saved = localStorage.getItem('cyoa-data')
+      if (saved) {
+        try {
+          data = JSON.parse(saved)
+        } catch {
+          /* ignore */
+        }
+      }
+      setProjectStart(Date.now())
+    }
+    if (data) {
       try {
-        const data = JSON.parse(saved)
         const loaded = (data.nodes || []).map(n => ({
           id: n.id,
           type: 'card',
@@ -109,6 +147,7 @@ export default function App() {
         setNodes(loaded)
         setEdges(scanEdges(loaded))
         setNextId(data.nextNodeId || 1)
+        setProjectName(data.projectName || '')
       } catch {
         // ignore corrupt data
       }
@@ -543,8 +582,31 @@ export default function App() {
     )
   }
 
+  const handleProjectSwitch = id => {
+    const p = projects[id]
+    if (!p) return
+    const loaded = (p.data.nodes || []).map(n => ({
+      id: n.id,
+      type: 'card',
+      position: n.position || { x: 0, y: 0 },
+      data: { text: n.text || '', title: n.title || '' },
+      width: n.width ?? 254,
+      height: n.height ?? estimateNodeHeight(n.text || ''),
+    }))
+    setNodes(loaded)
+    setEdges(scanEdges(loaded))
+    setNextId(p.data.nextNodeId || 1)
+    setProjectName(p.data.projectName || '')
+    setCurrentId(null)
+    setText('')
+    setTitle('')
+    setProjectId(id)
+    setProjectStart(p.start || Date.now())
+  }
+
   const exportProject = () => {
     const data = {
+      projectName,
       nextNodeId: nextId,
       nodes: nodes.map(n => ({
         id: n.id,
@@ -620,6 +682,7 @@ export default function App() {
       setNodes(loaded)
       setEdges(scanEdges(loaded))
       setNextId(data.nextNodeId || 1)
+      setProjectName(data.projectName || '')
       setCurrentId(null)
       setText('')
       setTitle('')
@@ -665,6 +728,7 @@ export default function App() {
   // Persist data after every change
   useEffect(() => {
     const data = {
+      projectName,
       nextNodeId: nextId,
       nodes: nodes.map(n => ({
         id: n.id,
@@ -677,7 +741,29 @@ export default function App() {
       })),
     }
     localStorage.setItem('cyoa-data', JSON.stringify(data))
-  }, [nodes, nextId])
+    if (autoSave) {
+      setProjects(p => {
+        const now = Date.now()
+        const prev = p[projectId] || { id: projectId, start: projectStart }
+        return {
+          ...p,
+          [projectId]: { ...prev, updated: now, data },
+        }
+      })
+    }
+  }, [nodes, nextId, projectName, autoSave])
+
+  useEffect(() => {
+    localStorage.setItem('cyoa-projects', JSON.stringify(projects))
+  }, [projects])
+
+  useEffect(() => {
+    localStorage.setItem('cyoa-current', projectId)
+  }, [projectId])
+
+  useEffect(() => {
+    localStorage.setItem('cyoa-auto-save', JSON.stringify(autoSave))
+  }, [autoSave])
 
 
   return (
@@ -706,6 +792,28 @@ export default function App() {
           onChange={e => setProjectName(e.target.value)}
           placeholder="Projektnamn"
         />
+        <label id="autoSaveLabel" style={{ display: 'flex', alignItems: 'center' }}>
+          <input
+            id="autoSave"
+            type="checkbox"
+            checked={autoSave}
+            onChange={e => setAutoSave(e.target.checked)}
+          />
+          Save
+        </label>
+        <select
+          id="projectList"
+          value={projectId}
+          onChange={e => handleProjectSwitch(e.target.value)}
+        >
+          {Object.values(projects)
+            .sort((a, b) => (b.updated || 0) - (a.updated || 0))
+            .map(p => (
+              <option key={p.id} value={p.id}>
+                {p.data.projectName?.trim() || new Date(p.start).toLocaleString()}
+              </option>
+            ))}
+        </select>
         <Button variant="ghost" icon={Download} onClick={exportProject}>
           Export
         </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -143,6 +143,21 @@ main {
   font-size: 1rem;
 }
 
+#projectList {
+  background: var(--bg);
+  color: var(--text);
+  border: none;
+  border-bottom: 1px solid var(--panel);
+  padding: var(--gap);
+  font-size: 1rem;
+}
+
+#autoSaveLabel {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
 #formatting-toolbar {
   display: flex;
   gap: 0.25rem;


### PR DESCRIPTION
## Summary
- store project name when exporting and importing JSON
- provide autosave option and list of saved projects
- tweak styles for new controls
- update README with autosave details

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68429e731e90832f8bc3efb07766ba71