### PR TITLE
Implement AI proofreading and UI improvements

### DIFF
--- a/src/AiProofreadPanel.jsx
+++ b/src/AiProofreadPanel.jsx
@@ -1,0 +1,24 @@
+import Button from './Button.jsx'
+
+export default function AiProofreadPanel({ original = '', improved = '', onApply, onClose }) {
+  return (
+    <div id="modal" role="dialog" aria-modal="true" className="show">
+      <button
+        id="closeModal"
+        className="btn ghost"
+        aria-label="Close"
+        onClick={onClose}
+      >
+        Close
+      </button>
+      <div id="modalList">
+        <h3>AI Proofread</h3>
+        <p>Original:</p>
+        <div className="suggestion">{original}</div>
+        <p>Improved:</p>
+        <div className="suggestion">{improved}</div>
+        <Button variant="primary" onClick={() => onApply(improved)}>Use text</Button>
+      </div>
+    </div>
+  )
+}

--- a/src/AiSettingsModal.jsx
+++ b/src/AiSettingsModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import Button from './Button.jsx'
-import { defaultPrompt } from './useAi.js'
+import { defaultPrompt, defaultProofPrompt } from './useAi.js'
 
 export default function AiSettingsModal({ settings, onChange, onClose }) {
   const [local, setLocal] = useState(settings)
@@ -96,6 +96,21 @@ export default function AiSettingsModal({ settings, onChange, onClose }) {
             className="reset-btn"
             type="button"
             onClick={() => update({ customPrompt: defaultPrompt })}
+          >
+            Reset to default
+          </Button>
+        </div>
+        <div>
+          <label>Proofread prompt</label>
+          <textarea
+            value={local.proofPrompt}
+            onChange={e => update({ proofPrompt: e.target.value })}
+            rows="3"
+          />
+          <Button
+            className="reset-btn"
+            type="button"
+            onClick={() => update({ proofPrompt: defaultProofPrompt })}
           >
             Reset to default
           </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -327,6 +327,17 @@ main {
   overflow: hidden;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  position: relative;
+}
+.node-card .preview-more {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(31, 41, 55, 0) 0%, var(--card) 70%);
+  color: var(--text-dim);
 }
 .node-card .node-textarea {
   flex: 1;


### PR DESCRIPTION
## Summary
- display indicator when node text overflows
- allow node auto-size on resize handle double-click
- disable editing when no node is selected
- support AI proofread of node text with customizable prompt
- expose proofread prompt in settings

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842a0773934832f9da2f57b80039ee5