### PR TITLE
Fix cursor jump in text editors

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -11,9 +11,13 @@ const NodeCard = memo(({ id, data, selected }) => {
   const [overflow, setOverflow] = useState(false)
   const textRef = useRef(null)
   const previewRef = useRef(null)
+  const prevSelectedRef = useRef(selected)
 
   useEffect(() => {
-    if (selected) textRef.current?.focus()
+    if (selected && !prevSelectedRef.current) {
+      textRef.current?.focus()
+    }
+    prevSelectedRef.current = selected
   }, [selected])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure focus only occurs when node selection changes to avoid stealing focus from other text fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a41b9568832f8916f32c8db0fd7b