### PR TITLE
Improve linear view formatting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -106,11 +106,20 @@ export default function App() {
   const [showProofread, setShowProofread] = useState(false)
   const [editorCollapsed, setEditorCollapsed] = useState(false)
   const [loadingAi, setLoadingAi] = useState(false)
+  const [fontSize, setFontSize] = useState(() => {
+    const stored = localStorage.getItem('cyoa-font-size')
+    return stored ? Number(stored) : 14
+  })
   const textRef = useRef(null)
   const importRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
   const undoStack = useRef([])
   const redoStack = useRef([])
+
+  useEffect(() => {
+    document.documentElement.style.setProperty('--font-size', `${fontSize}px`)
+    localStorage.setItem('cyoa-font-size', String(fontSize))
+  }, [fontSize])
 
   // Restore previous session from localStorage on initial load
   useEffect(() => {
@@ -867,6 +876,12 @@ export default function App() {
         <Button variant="ghost" icon={Play} onClick={() => setShowPlay(true)}>
           Playthrough
         </Button>
+        <Button variant="ghost" onClick={() => setFontSize(f => Math.max(10, f - 1))}>
+          A-
+        </Button>
+        <Button variant="ghost" onClick={() => setFontSize(f => f + 1)}>
+          A+
+        </Button>
         <Button
           id="settingsButton"
           variant="ghost"
@@ -969,6 +984,7 @@ export default function App() {
           text={linearText}
           setText={setLinearText}
           setNodes={setNodes}
+          nextId={nextId}
           onClose={() => setShowModal(false)}
         />
       )}

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { Plus } from 'lucide-react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -14,7 +15,7 @@ function postprocess(md = '') {
   return md.replace(/\[#(\d{3})\]\(#\1\)/g, '[#$1]')
 }
 
-export default function LinearView({ text, setText, setNodes, onClose }) {
+export default function LinearView({ text, setText, setNodes, nextId, onClose }) {
   const editor = useEditor({
     extensions: [
       StarterKit,
@@ -35,6 +36,12 @@ export default function LinearView({ text, setText, setNodes, onClose }) {
   }, [text, editor])
 
   useLinearParser(text, setNodes)
+
+  const insertNextNodeNumber = () => {
+    if (!editor) return
+    const nodeId = `#${String(nextId).padStart(3, '0')}`
+    editor.chain().focus().insertContent(nodeId).run()
+  }
 
   useEffect(() => {
     if (!editor) return
@@ -101,6 +108,14 @@ export default function LinearView({ text, setText, setNodes, onClose }) {
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
         >
           H2
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={insertNextNodeNumber}
+          aria-label="Next node number"
+        >
+          <Plus aria-hidden="true" />
         </button>
       </div>
       <button

--- a/src/index.css
+++ b/src/index.css
@@ -8,7 +8,7 @@ body {
   background: var(--bg);
   color: var(--text);
   font-family: Inter, sans-serif;
-  font-size: 14px;
+  font-size: var(--font-size);
 }
 #root {
   display: flex;
@@ -206,7 +206,7 @@ main {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: #121212;
+  background: var(--modal-bg);
   color: #f0f0f0;
   display: none;
   flex-direction: column;
@@ -227,12 +227,16 @@ main {
   padding: 1rem;
   max-width: 800px;
   margin: auto;
+  background: var(--panel);
+  border-radius: var(--radius);
+  border: 1px solid var(--panel);
   line-height: 1.6;
   font-family: system-ui, sans-serif;
   user-select: text;
 }
 #modalList a {
-  color: #70b8ff;
+  color: inherit;
+  text-decoration: underline;
 }
 #modalList a:hover {
   text-decoration: underline;
@@ -449,18 +453,24 @@ main {
 
 #linearEditor h3 {
   font-size: 20px;
-  margin: 2.5rem 0 .25rem;
+  margin: 1rem 0 .25rem;
 }
 
 #linearEditor p {
   margin: .25rem 0;
+  line-height: 1.4;
 }
 
 .node-link {
-  color: #2fa8ff;
-  text-decoration: none;
+  color: inherit;
+  text-decoration: underline;
 }
 
 .node-link:hover {
   text-decoration: underline;
+}
+
+input:focus,
+textarea:focus {
+  outline: none;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -9,4 +9,6 @@
   --gap: 0.5rem;
   --btn: #4a5568;
   --btn-hover: #5b667a;
+  --font-size: 14px;
+  --modal-bg: #222;
 }


### PR DESCRIPTION
## Summary
- add global font size controls and persist in localStorage
- tweak modal appearance and link styling
- allow inserting the next node number in Linear View
- adjust spacing and line heights
- remove focus outlines

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842a560ca90832faab5647f60bcb89f