### PR TITLE
Implement UI fixes for text editing

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -5,10 +5,11 @@ import '@reactflow/node-resizer/dist/style.css'
 import NodeEditorContext from './NodeEditorContext.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
-  const { setNodes } = useReactFlow()
+  const { setNodes, getNodes } = useReactFlow()
   const { updateNodeText } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
   const [overflow, setOverflow] = useState(false)
+  const [invalidRef, setInvalidRef] = useState(false)
   const textRef = useRef(null)
   const previewRef = useRef(null)
   const prevSelectedRef = useRef(selected)
@@ -27,6 +28,17 @@ const NodeCard = memo(({ id, data, selected }) => {
     }
   }, [data.text, selected])
 
+  useEffect(() => {
+    const nodes = new Set(getNodes().map(n => n.id))
+    const pattern = /#(\d{3})/g
+    let m
+    let invalid = /#XXX/.test(data.text || '')
+    while (!invalid && (m = pattern.exec(data.text || ''))) {
+      if (!nodes.has(m[1])) invalid = true
+    }
+    setInvalidRef(invalid)
+  }, [data.text, getNodes])
+
   const handleResizeEnd = (_e, { width, height }) => {
     setResizing(false)
     setNodes(ns =>
@@ -43,6 +55,7 @@ const NodeCard = memo(({ id, data, selected }) => {
 
   return (
     <div className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}>
+      {invalidRef && <div className="invalid-dot" />}
       <div className="node-header">
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}

--- a/src/index.css
+++ b/src/index.css
@@ -200,6 +200,7 @@ main {
   font-family: 'Inter', sans-serif;
   overflow-y: auto;
   scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 #text::-webkit-scrollbar {
   display: none;
@@ -364,6 +365,7 @@ main {
   overflow-wrap: anywhere;
   overflow-y: auto;
   scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 .node-card .node-textarea::-webkit-scrollbar {
   display: none;
@@ -471,6 +473,11 @@ main {
   outline: none;
   white-space: pre-wrap;
   overflow-y: auto;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+#linearEditor::-webkit-scrollbar {
+  display: none;
 }
 
 .linear-id {

--- a/src/index.css
+++ b/src/index.css
@@ -197,7 +197,16 @@ main {
   border: none;
   background: var(--bg);
   color: var(--text);
-  font-family: ui-monospace, SFMono-Regular;
+  font-family: 'Inter', sans-serif;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+#text::-webkit-scrollbar {
+  display: none;
+}
+#text:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 #modal {
@@ -349,10 +358,28 @@ main {
   border: none;
   background: transparent;
   color: var(--text);
-  font-family: ui-monospace, SFMono-Regular;
+  font-family: 'Inter', sans-serif;
   resize: none;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.node-card .node-textarea::-webkit-scrollbar {
+  display: none;
+}
+.node-card .node-textarea:focus {
+  outline: none;
+  box-shadow: none;
+}
+.node-card .invalid-dot {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 8px;
+  height: 8px;
+  background: #dc2626;
+  border-radius: 50%;
 }
 
 .resize-handle {
@@ -473,4 +500,5 @@ main {
 input:focus,
 textarea:focus {
   outline: none;
+  box-shadow: none;
 }


### PR DESCRIPTION
## Summary
- keep editor fonts consistent with sans-serif
- hide scrollbars in node editor and right panel text area
- remove focus outlines from inputs and textareas
- flag invalid node references with a red dot

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842b0a47f30832fb02fc22d0e1f9361