### PR TITLE
Fix node resizing and font styles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -222,7 +222,8 @@ export default function App() {
   const onNodesChange = useCallback(
     changes => {
       pushUndoState()
-      setNodes(ns => applyNodeChanges(changes, ns))
+      const filtered = changes.filter(c => c.type !== 'dimensions')
+      setNodes(ns => applyNodeChanges(filtered, ns))
     },
     [pushUndoState]
   )

--- a/src/index.css
+++ b/src/index.css
@@ -336,7 +336,7 @@ main {
   white-space: nowrap;
 }
 .node-card .node-preview {
-  color: var(--text-dim);
+  color: var(--text);
   flex: 1;
   overflow: hidden;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- prevent node size resets by ignoring `dimensions` updates
- keep node text styling consistent when editing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842d91e6f4c832fbde3954f067ae532