### PR TITLE
Improve responsive layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -104,7 +104,9 @@ export default function App() {
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [proofreadResult, setProofreadResult] = useState(null)
   const [showProofread, setShowProofread] = useState(false)
-  const [editorCollapsed, setEditorCollapsed] = useState(false)
+  const [editorCollapsed, setEditorCollapsed] = useState(() =>
+    window.innerWidth < 768
+  )
   const [loadingAi, setLoadingAi] = useState(false)
   const [fontSize, setFontSize] = useState(() => {
     const stored = localStorage.getItem('cyoa-font-size')

--- a/src/index.css
+++ b/src/index.css
@@ -75,7 +75,8 @@ header {
 
 main {
   flex: 1;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto;
   overflow: hidden;
 }
 
@@ -164,6 +165,8 @@ main {
   padding: 0.25rem 0;
   border-bottom: 1px solid var(--panel);
   background: var(--panel);
+  overflow-x: auto;
+  white-space: nowrap;
 }
 
 .ai-loading {
@@ -189,6 +192,8 @@ main {
   border-bottom: 1px solid var(--panel);
   background: var(--panel);
   margin: 0 var(--gap);
+  overflow-x: auto;
+  white-space: nowrap;
 }
 
 #text {
@@ -220,6 +225,7 @@ main {
   color: #f0f0f0;
   display: none;
   flex-direction: column;
+  z-index: 1000;
 }
 
 #modal.show {
@@ -435,6 +441,7 @@ main {
   display: none;
   flex-direction: column;
   padding: 0.5rem;
+  z-index: 1000;
 }
 
 #playthrough.show {
@@ -508,4 +515,25 @@ input:focus,
 textarea:focus {
   outline: none;
   box-shadow: none;
+}
+
+@media (max-width: 768px) {
+  main {
+    grid-template-columns: 1fr;
+  }
+  #editor {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100vh;
+    width: 100vw;
+    max-width: none;
+    z-index: 1000;
+  }
+  #toggleEditor {
+    right: 0 !important;
+  }
+  .react-flow__minimap {
+    display: none;
+  }
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -12,3 +12,10 @@
   --font-size: 14px;
   --modal-bg: #222;
 }
+
+@media (max-width: 768px) {
+  :root {
+    --font-size: 12px;
+    --gap: 0.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- use CSS grid layout for main area and hide minimap on mobile
- make editor overlay on small screens
- adjust button toolbars to scroll horizontally
- reduce font size and gap on mobile
- collapse editor by default on narrow screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842fe4d0e40832f8dfcaf4c3f5b6b32