### PR TITLE
Fix node layout on selection

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,25 +1,15 @@
-import { memo, useState, useContext, useEffect, useRef } from 'react'
+import { memo, useState, useEffect, useRef } from 'react'
 import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
-import NodeEditorContext from './NodeEditorContext.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { setNodes, getNodes } = useReactFlow()
-  const { updateNodeText } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
   const [overflow, setOverflow] = useState(false)
   const [invalidRef, setInvalidRef] = useState(false)
-  const textRef = useRef(null)
   const previewRef = useRef(null)
-  const prevSelectedRef = useRef(selected)
 
-  useEffect(() => {
-    if (selected && !prevSelectedRef.current) {
-      textRef.current?.focus()
-    }
-    prevSelectedRef.current = selected
-  }, [selected])
 
   useEffect(() => {
     const el = previewRef.current
@@ -47,7 +37,7 @@ const NodeCard = memo(({ id, data, selected }) => {
   }
 
   const autoResize = () => {
-    const el = textRef.current || previewRef.current
+    const el = previewRef.current
     if (!el) return
     const height = Math.min(300, Math.max(100, el.scrollHeight + 16))
     setNodes(ns => ns.map(n => (n.id === id ? { ...n, height } : n)))
@@ -60,26 +50,11 @@ const NodeCard = memo(({ id, data, selected }) => {
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}
       </div>
-      {selected ? (
-        <textarea
-          ref={textRef}
-          className="node-textarea"
-          value={data.text}
-          onChange={e => {
-            let value = e.target.value
-            value = value.replace(/(^|[^[])#(\d{3})(?!\])/g, (_, p1, p2) => `${p1}[#${p2}]`)
-            if (updateNodeText) {
-              updateNodeText(id, value)
-            }
-          }}
-        />
-      ) : (
-        data.text && (
-          <div ref={previewRef} className="node-preview">
-            {data.text}
-            {overflow && <div className="preview-more">...</div>}
-          </div>
-        )
+      {data.text && (
+        <div ref={previewRef} className="node-preview">
+          {data.text}
+          {overflow && <div className="preview-more">...</div>}
+        </div>
       )}
       <NodeResizeControl
         variant={ResizeControlVariant.Handle}


### PR DESCRIPTION
## Summary
- avoid switching to textarea when a node is selected
- keep node layout consistent while still showing preview

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68443f2ce6c8832f81c55dbf366f93b2