### PR TITLE
Refactor header menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm run dev
 npm run build
 ```
 
-Project data can be saved locally. Tick the **Save** checkbox next to the project name to autosave the current story. Saved stories appear in the dropdown list in the header so you can quickly switch between them. The **Export** and **Import** buttons let you download or load `.json` files. The exported file now also contains the project name. The **Export MD** button downloads a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
+Project data can be saved locally. Tick the **Save** checkbox next to the project name to autosave the current story. Saved stories appear in the dropdown list in the header so you can quickly switch between them. Export and import options are available from the floating menu in the bottom right. The exported file contains the project name. Use **Export MD** in the header to download a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
 
 All rendered Markdown is sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) to prevent unwanted HTML injection.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -855,14 +855,8 @@ export default function App() {
               </option>
             ))}
         </select>
-        <Button variant="ghost" icon={Download} onClick={exportProject}>
-          Export
-        </Button>
         <Button variant="ghost" icon={FileText} onClick={exportMarkdown}>
           Export MD
-        </Button>
-        <Button variant="ghost" icon={Upload} onClick={() => importRef.current?.click()}>
-          Import
         </Button>
         <input
           ref={importRef}
@@ -894,14 +888,7 @@ export default function App() {
         <Button variant="ghost" onClick={() => setFontSize(f => f + 1)}>
           A+
         </Button>
-        <Button
-          id="settingsButton"
-          variant="ghost"
-          icon={Settings}
-          aria-label="Settings"
-          style={{ marginLeft: 'auto' }}
-          onClick={() => setShowAiSettings(true)}
-        />
+        
       </header>
       <main style={{ position: 'relative' }}>
         <div id="graph">

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -11,19 +11,20 @@ export default function FloatingMenu({
 }) {
   return (
     <Popover className="fixed bottom-4 right-4 z-50">
-      {() => (
+      {({ open }) => (
         <>
           <Popover.Button className="rounded-full bg-[var(--btn)] p-3 text-[var(--text)] shadow-lg hover:bg-[var(--btn-hover)] focus:outline-none">
             <Menu className="h-5 w-5" aria-hidden="true" />
           </Popover.Button>
           <Transition
             as={Fragment}
-            enter="transition duration-150 ease-out"
-            enterFrom="opacity-0 scale-95"
-            enterTo="opacity-100 scale-100"
-            leave="transition duration-100 ease-in"
-            leaveFrom="opacity-100 scale-100"
-            leaveTo="opacity-0 scale-95"
+            show={open}
+            enter="transition transform duration-200 ease-out"
+            enterFrom="opacity-0 translate-y-2"
+            enterTo="opacity-100 translate-y-0"
+            leave="transition transform duration-150 ease-in"
+            leaveFrom="opacity-100 translate-y-0"
+            leaveTo="opacity-0 translate-y-2"
           >
             <Popover.Panel className="mt-2 flex flex-col gap-1 rounded-lg bg-[var(--panel)] p-2 text-sm text-[var(--text)] shadow-lg">
               <button


### PR DESCRIPTION
## Summary
- animate the floating menu
- move export/import/options to floating menu
- update readme for floating menu location

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844412dfb90832f9309723df4b2785d