### PR TITLE
Fix node editing regression

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -1,15 +1,25 @@
-import { memo, useState, useEffect, useRef } from 'react'
+import { memo, useState, useContext, useEffect, useRef } from 'react'
 import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
+import NodeEditorContext from './NodeEditorContext.js'
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { setNodes, getNodes } = useReactFlow()
+  const { updateNodeText } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
   const [overflow, setOverflow] = useState(false)
   const [invalidRef, setInvalidRef] = useState(false)
+  const textRef = useRef(null)
   const previewRef = useRef(null)
+  const prevSelectedRef = useRef(selected)
 
+  useEffect(() => {
+    if (selected && !prevSelectedRef.current) {
+      textRef.current?.focus()
+    }
+    prevSelectedRef.current = selected
+  }, [selected])
 
   useEffect(() => {
     const el = previewRef.current
@@ -37,7 +47,7 @@ const NodeCard = memo(({ id, data, selected }) => {
   }
 
   const autoResize = () => {
-    const el = previewRef.current
+    const el = textRef.current || previewRef.current
     if (!el) return
     const height = Math.min(300, Math.max(100, el.scrollHeight + 16))
     setNodes(ns => ns.map(n => (n.id === id ? { ...n, height } : n)))
@@ -50,11 +60,26 @@ const NodeCard = memo(({ id, data, selected }) => {
         <span className="node-id">#{id}</span>
         {data.title && <span className="node-title">{data.title}</span>}
       </div>
-      {data.text && (
-        <div ref={previewRef} className="node-preview">
-          {data.text}
-          {overflow && <div className="preview-more">...</div>}
-        </div>
+      {selected ? (
+        <textarea
+          ref={textRef}
+          className="node-textarea"
+          value={data.text}
+          onChange={e => {
+            let value = e.target.value
+            value = value.replace(/(^|[^[])#(\d{3})(?!\])/g, (_, p1, p2) => `${p1}[#${p2}]`)
+            if (updateNodeText) {
+              updateNodeText(id, value)
+            }
+          }}
+        />
+      ) : (
+        data.text && (
+          <div ref={previewRef} className="node-preview">
+            {data.text}
+            {overflow && <div className="preview-more">...</div>}
+          </div>
+        )
       )}
       <NodeResizeControl
         variant={ResizeControlVariant.Handle}


### PR DESCRIPTION
## Summary
- restore NodeCard features for editing node text directly
- allow resize handle to work again

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68444218a45c832f95fe7cb5f3f71ad0