### PR TITLE
Move export and view actions to floating menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,10 +5,7 @@ import {
   RotateCcw,
   RotateCw,
   Download,
-  FileText,
   Upload,
-  List,
-  Play,
   Cloud,
   SpellCheck,
   Settings,
@@ -745,6 +742,20 @@ export default function App() {
     setEdges(layoutedEdges)
   }, [nodes, edges, pushUndoState])
 
+  const openLinearView = () => {
+    const md = nodes
+      .slice()
+      .sort((a, b) => Number(a.id) - Number(b.id))
+      .map(n => `## #${n.id} ${n.data.title}\n${n.data.text}`)
+      .join('\n')
+    setLinearText(md)
+    setShowModal(true)
+  }
+
+  const startPlaythrough = () => {
+    setShowPlay(true)
+  }
+
   useEffect(() => {
     const handler = e => {
       if ((e.metaKey || e.ctrlKey) && e.key === 'z' && !e.shiftKey) {
@@ -822,11 +833,6 @@ export default function App() {
         <Button variant="ghost" icon={RotateCw} onClick={redo}>
           Redo
         </Button>
-        {!showModal && !showPlay && (
-          <Button variant="ghost" onClick={handleAutoLayout}>
-            Auto-layout
-          </Button>
-        )}
         <input
           id="projectName"
           value={projectName}
@@ -855,33 +861,12 @@ export default function App() {
               </option>
             ))}
         </select>
-        <Button variant="ghost" icon={FileText} onClick={exportMarkdown}>
-          Export MD
-        </Button>
         <input
           ref={importRef}
           type="file"
           onChange={importProject}
           style={{ display: 'none' }}
         />
-        <Button
-          variant="ghost"
-          icon={List}
-          onClick={() => {
-            const md = nodes
-              .slice()
-              .sort((a, b) => Number(a.id) - Number(b.id))
-              .map(n => `## #${n.id} ${n.data.title}\n${n.data.text}`)
-              .join('\n')
-            setLinearText(md)
-            setShowModal(true)
-          }}
-        >
-          Linear View
-        </Button>
-        <Button variant="ghost" icon={Play} onClick={() => setShowPlay(true)}>
-          Playthrough
-        </Button>
         <Button variant="ghost" onClick={() => setFontSize(f => Math.max(10, f - 1))}>
           A-
         </Button>
@@ -1021,6 +1006,10 @@ export default function App() {
         onImport={() => importRef.current?.click()}
         onShowSettings={openSettings}
         onShowAiSettings={() => setShowAiSettings(true)}
+        onExportMd={exportMarkdown}
+        onLinearView={openLinearView}
+        onPlaythrough={startPlaythrough}
+        onAutoLayout={!showModal && !showPlay ? handleAutoLayout : undefined}
         onHelp={openHelp}
       />
     </>

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -1,12 +1,26 @@
 import { Fragment } from 'react'
 import { Popover, Transition } from '@headlessui/react'
-import { Menu, Upload, Download, Settings, HelpCircle } from 'lucide-react'
+import {
+  Menu,
+  Upload,
+  Download,
+  Settings,
+  HelpCircle,
+  FileText,
+  List,
+  Play,
+  LayoutGrid,
+} from 'lucide-react'
 
 export default function FloatingMenu({
   onExport,
   onImport,
   onShowSettings,
   onShowAiSettings,
+  onExportMd,
+  onLinearView,
+  onPlaythrough,
+  onAutoLayout,
   onHelp,
 }) {
   return (
@@ -33,6 +47,38 @@ export default function FloatingMenu({
               >
                 <span className="flex items-center gap-2"><Download className="h-4 w-4" />Export</span>
               </button>
+              {onExportMd && (
+                <button
+                  className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                  onClick={onExportMd}
+                >
+                  <span className="flex items-center gap-2"><FileText className="h-4 w-4" />Export MD</span>
+                </button>
+              )}
+              {onLinearView && (
+                <button
+                  className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                  onClick={onLinearView}
+                >
+                  <span className="flex items-center gap-2"><List className="h-4 w-4" />Linear View</span>
+                </button>
+              )}
+              {onPlaythrough && (
+                <button
+                  className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                  onClick={onPlaythrough}
+                >
+                  <span className="flex items-center gap-2"><Play className="h-4 w-4" />Playthrough</span>
+                </button>
+              )}
+              {onAutoLayout && (
+                <button
+                  className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                  onClick={onAutoLayout}
+                >
+                  <span className="flex items-center gap-2"><LayoutGrid className="h-4 w-4" />Auto-layout</span>
+                </button>
+              )}
               <button
                 className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
                 onClick={onImport}


### PR DESCRIPTION
## Summary
- move Export MD, Linear View, Playthrough and Auto-layout buttons from header to the floating menu
- add callbacks in FloatingMenu and App
- clean up unused icon imports

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6844466b8a64832fb5b1efcbddf7a675