### PR TITLE
Add English help file and translate UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Välj-väg-verktyg
+# Choose Your Path Tool
 
 This project is now built with [Vite](https://vitejs.dev/) and [React](https://react.dev). The interactive graph is rendered using [React Flow](https://reactflow.dev/).
 

--- a/help.html
+++ b/help.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Choose Your Path Tool - Help</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="p-6 prose max-w-none">
+  <h1>Help</h1>
+  <p>This tool lets you build interactive choose-your-path stories. Each node represents a section of the story and can link to other nodes using Markdown references.</p>
+  <h2>Creating Nodes</h2>
+  <ul>
+    <li>Click on an empty area of the graph to create a new node.</li>
+    <li>Edit the title and body text directly inside the node.</li>
+    <li>Type <code>#001</code> to create a reference or use Markdown links such as <code>[Continue → #002](#002)</code>.</li>
+  </ul>
+  <h2>Managing Projects</h2>
+  <ul>
+    <li>Enable <strong>Save</strong> next to the project name to store the current story locally.</li>
+    <li>Use the floating menu in the bottom right to export or import projects.</li>
+    <li>Select <strong>Export MD</strong> in the header to download all nodes as a Markdown file.</li>
+  </ul>
+  <h2>Playthrough</h2>
+  <ul>
+    <li>Choose <strong>Play</strong> from the floating menu to read through the story starting from the current node.</li>
+  </ul>
+  <h2>AI Features</h2>
+  <ul>
+    <li>Configure API settings under <strong>AI Settings</strong> in the floating menu.</li>
+    <li>The cloud icon generates suggestions for how the story might continue.</li>
+    <li>The spell check icon proofreads the current text.</li>
+  </ul>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Välj-väg-verktyg</title>
+    <title>Choose Your Path Tool</title>
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -678,7 +678,7 @@ export default function App() {
         const heading = `## #${n.id}${n.data.title ? ` ${n.data.title}` : ''}`
         const body = (n.data.text || '').replace(/\[#(\d{3})]|#(\d{3})/g, (_m, p1, p2) => {
           const id = p1 || p2
-          return `[Gå vidare → #${id}](#${id})`
+          return `[Continue → #${id}](#${id})`
         })
         return `${heading}\n${body}`
       })
@@ -728,7 +728,7 @@ export default function App() {
   }
 
   const openHelp = () => {
-    alert('Help is not implemented yet')
+    window.open('help.html', '_blank')
   }
 
   const handleAutoLayout = useCallback(() => {
@@ -942,7 +942,7 @@ export default function App() {
             <SpellCheck aria-hidden="true" />
           </button>
           <span className={`ai-loading${loadingAi ? ' show' : ''}`} aria-live="polite">
-            Genererar förslag…
+            Generating suggestions…
           </span>
           {/* Settings button moved to header */}
         </div>

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -89,20 +89,20 @@ export default function FloatingMenu({
                 className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
                 onClick={onShowSettings}
               >
-                <span className="flex items-center gap-2"><Settings className="h-4 w-4" />Inställningar</span>
+                <span className="flex items-center gap-2"><Settings className="h-4 w-4" />Settings</span>
               </button>
               <button
                 className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
                 onClick={onShowAiSettings}
               >
-                <span className="flex items-center gap-2"><Settings className="h-4 w-4" />AI-inställningar</span>
+                <span className="flex items-center gap-2"><Settings className="h-4 w-4" />AI Settings</span>
               </button>
               {onHelp && (
                 <button
                   className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
                   onClick={onHelp}
                 >
-                  <span className="flex items-center gap-2"><HelpCircle className="h-4 w-4" />Hjälp</span>
+                  <span className="flex items-center gap-2"><HelpCircle className="h-4 w-4" />Help</span>
                 </button>
               )}
             </Popover.Panel>

--- a/src/useAi.js
+++ b/src/useAi.js
@@ -3,10 +3,10 @@ import { useState, useEffect } from 'react'
 const STORAGE_KEY = 'ai-settings'
 
 export const defaultPrompt =
-  'Du skriver en interaktiv berättelse. Här är tidigare noder...\n\n'
+  'You are writing an interactive story. Here are the previous nodes...\n\n'
 
 export const defaultProofPrompt =
-  'Korrigera och förbättra texten nedan språkligt utan att ändra innehållet:'
+  'Correct and improve the text below without changing the meaning:'
 
 const defaultSettings = {
   enabled: false,
@@ -56,7 +56,7 @@ export async function getSuggestions(nodes, currentId, settings) {
   const context = history
     .map(n => `#${n.id} ${n.data.title || ''}\n${n.data.text || ''}`)
     .join('\n\n')
-  const prompt = `${settings.customPrompt || defaultPrompt}${context}\n\nAktuell nod:\n#${current.id} ${current.data.title || ''}\nDu har skrivit: "${current.data.text || ''}"\n\nSkriv tre förslag på hur det kan fortsätta härifrån. Varje förslag bör vara 1–2 meningar.\nReturnera tre olika fortsättningar, börja varje med • och använd samma berättarstil som tidigare. Om du ger val, använd markdownlänkar som [#004].`
+  const prompt = `${settings.customPrompt || defaultPrompt}${context}\n\nCurrent node:\n#${current.id} ${current.data.title || ''}\nYou wrote: "${current.data.text || ''}"\n\nWrite three suggestions for how the story could continue from here. Each suggestion should be 1–2 sentences.\nReturn three different continuations, start each with • and keep the same narrative style as before. If you offer choices, use markdown links like [#004].`
 
   const body = {
     model: settings.model,


### PR DESCRIPTION
## Summary
- switch app language to English
- add `help.html` and link it from the Help menu
- update AI prompts, menu labels and messages to English
- rename the project in README and page title

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684480c4d84c832f90469513f6a7f160