### PR TITLE
Adjust AI settings modal textareas

### DIFF
--- a/src/AiSettingsModal.jsx
+++ b/src/AiSettingsModal.jsx
@@ -90,7 +90,7 @@ export default function AiSettingsModal({ settings, onChange, onClose }) {
           <textarea
             value={local.customPrompt}
             onChange={e => update({ customPrompt: e.target.value })}
-            rows="4"
+            rows="8"
           />
           <Button
             className="reset-btn"
@@ -105,7 +105,7 @@ export default function AiSettingsModal({ settings, onChange, onClose }) {
           <textarea
             value={local.proofPrompt}
             onChange={e => update({ proofPrompt: e.target.value })}
-            rows="3"
+            rows="6"
           />
           <Button
             className="reset-btn"

--- a/src/index.css
+++ b/src/index.css
@@ -280,6 +280,16 @@ main {
   margin: 0.5rem 0;
 }
 
+#modalList input:not([type="checkbox"]),
+#modalList textarea {
+  width: 100%;
+  color: #000;
+}
+
+#modalList textarea {
+  min-height: 8rem;
+}
+
 .suggestion {
   background: var(--card);
   border: 1px solid var(--panel);


### PR DESCRIPTION
## Summary
- enlarge AI prompt textareas to 8 and 6 rows
- make inputs and textareas in the AI settings modal darker and full width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684485608100832fb89ad2f1d741fb3f