### PR TITLE
Add shared node dimension constants

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import { useAiSettings, getSuggestions, proofreadText } from './useAi.js'
 import AiProofreadPanel from './AiProofreadPanel.jsx'
 import Button from './Button.jsx'
 import FloatingMenu from './FloatingMenu.jsx'
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './constants.js'
 
 function estimateNodeHeight(text) {
   const charsPerLine = 32
@@ -155,7 +156,7 @@ export default function App() {
           type: 'card',
           position: n.position || { x: 0, y: 0 },
           data: { text: n.text || '', title: n.title || '' },
-          width: n.width ?? 254,
+          width: n.width ?? DEFAULT_NODE_WIDTH,
           height: n.height ?? estimateNodeHeight(n.text || ''),
         }))
         setNodes(loaded)
@@ -494,8 +495,8 @@ export default function App() {
           position,
           type: 'card',
           data: { text: '', title: '' },
-          width: 254,
-          height: 100,
+          width: DEFAULT_NODE_WIDTH,
+          height: DEFAULT_NODE_HEIGHT,
         },
       ]
       setEdges(scanEdges(updated))
@@ -573,8 +574,8 @@ export default function App() {
                 type: 'card',
                 position: { x: baseX + 300, y: baseY + idx * 100 },
                 data: { text: '', title: '' },
-                width: 254,
-                height: 100,
+                width: DEFAULT_NODE_WIDTH,
+                height: DEFAULT_NODE_HEIGHT,
               },
             ]
             idx += 1
@@ -619,7 +620,7 @@ export default function App() {
       type: 'card',
       position: n.position || { x: 0, y: 0 },
       data: { text: n.text || '', title: n.title || '' },
-      width: n.width ?? 254,
+      width: n.width ?? DEFAULT_NODE_WIDTH,
       height: n.height ?? estimateNodeHeight(n.text || ''),
     }))
     setNodes(loaded)
@@ -705,7 +706,7 @@ export default function App() {
         type: 'card',
         position: n.position || { x: 0, y: 0 },
         data: { text: n.text || '', title: n.title || '' },
-        width: n.width ?? 254,
+        width: n.width ?? DEFAULT_NODE_WIDTH,
         height: n.height ?? estimateNodeHeight(n.text || ''),
       }))
       setNodes(loaded)

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,2 @@
+export const DEFAULT_NODE_WIDTH = 254;
+export const DEFAULT_NODE_HEIGHT = 100;

--- a/src/dagreLayout.ts
+++ b/src/dagreLayout.ts
@@ -1,5 +1,6 @@
 import dagre from 'dagre'
 import type { Edge, Node } from 'reactflow'
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './constants.js'
 
 export default function getLayoutedElements(nodes: Node[], edges: Edge[], direction = 'LR') {
   const dagreGraph = new dagre.graphlib.Graph()
@@ -7,8 +8,8 @@ export default function getLayoutedElements(nodes: Node[], edges: Edge[], direct
   dagreGraph.setGraph({ rankdir: direction })
 
   nodes.forEach(node => {
-    const width = node.width ?? 250
-    const height = node.height ?? 100
+    const width = node.width ?? DEFAULT_NODE_WIDTH
+    const height = node.height ?? DEFAULT_NODE_HEIGHT
     dagreGraph.setNode(node.id, { width, height })
   })
 
@@ -20,7 +21,10 @@ export default function getLayoutedElements(nodes: Node[], edges: Edge[], direct
     const { x, y } = dagreGraph.node(node.id)
     return {
       ...node,
-      position: { x: x - (node.width ?? 250) / 2, y: y - (node.height ?? 100) / 2 },
+      position: {
+        x: x - (node.width ?? DEFAULT_NODE_WIDTH) / 2,
+        y: y - (node.height ?? DEFAULT_NODE_HEIGHT) / 2,
+      },
     }
   })
 

--- a/src/useLinearParser.js
+++ b/src/useLinearParser.js
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './constants.js'
 
 export default function useLinearParser(raw = '', setNodes) {
   useEffect(() => {
@@ -23,10 +24,10 @@ export default function useLinearParser(raw = '', setNodes) {
         return {
           id: p.id,
           type: 'card',
-          position: { x: 0, y: i * 100 },
+          position: { x: 0, y: i * DEFAULT_NODE_HEIGHT },
           data: { text: p.text, title: p.title },
-          width: 220,
-          height: 100,
+          width: DEFAULT_NODE_WIDTH,
+          height: DEFAULT_NODE_HEIGHT,
         }
       })
       return updated


### PR DESCRIPTION
## Summary
- centralize node dimension defaults in `src/constants.js`
- replace hard-coded widths and heights with the new constants
- update layout logic to use the shared defaults

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684489aae86c832f823686dcb00101c0