### PR TITLE
Add node color picker

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,3 +23,4 @@ Start a playthrough from the current node via **Play** in the floating menu.
 - Configure API settings under **AI Settings**.
 - The cloud icon suggests how the story might continue.
 - The spell check icon proofreads the current text.
+- Use the color square to assign a background color to the current node.

--- a/help.html
+++ b/help.html
@@ -30,6 +30,7 @@
     <li>Configure API settings under <strong>AI Settings</strong> in the floating menu.</li>
     <li>The cloud icon generates suggestions for how the story might continue.</li>
     <li>The spell check icon proofreads the current text.</li>
+    <li>The color square lets you change the background of the selected node.</li>
   </ul>
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,17 @@ import FloatingMenu from './FloatingMenu.jsx'
 import NewProjectModal from './NewProjectModal.jsx'
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './constants.js'
 
+const COLOR_OPTIONS = [
+  '#1f2937',
+  '#ef4444',
+  '#f97316',
+  '#facc15',
+  '#22c55e',
+  '#3b82f6',
+  '#e879f9',
+  '#d1d5db',
+]
+
 function estimateNodeHeight(text) {
   const charsPerLine = 32
   const lines = text
@@ -104,6 +115,7 @@ export default function App() {
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [proofreadResult, setProofreadResult] = useState(null)
   const [showProofread, setShowProofread] = useState(false)
+  const [showColorPicker, setShowColorPicker] = useState(false)
   const [showNewProject, setShowNewProject] = useState(false)
   const [editorCollapsed, setEditorCollapsed] = useState(() =>
     window.innerWidth < 768
@@ -157,7 +169,7 @@ export default function App() {
           id: n.id,
           type: 'card',
           position: n.position || { x: 0, y: 0 },
-          data: { text: n.text || '', title: n.title || '' },
+          data: { text: n.text || '', title: n.title || '', color: n.color || '#1f2937' },
           width: n.width ?? DEFAULT_NODE_WIDTH,
           height: n.height ?? estimateNodeHeight(n.text || ''),
         }))
@@ -318,6 +330,17 @@ export default function App() {
       area.selectionStart = area.selectionEnd = start + suggestion.length
     })
     setShowSuggestions(false)
+  }
+
+  const changeNodeColor = color => {
+    if (!currentId) return
+    pushUndoState()
+    setNodes(ns =>
+      ns.map(n =>
+        n.id === currentId ? { ...n, data: { ...n.data, color } } : n
+      )
+    )
+    setShowColorPicker(false)
   }
 
   const insertNextNodeNumber = () => {
@@ -496,7 +519,7 @@ export default function App() {
           id,
           position,
           type: 'card',
-          data: { text: '', title: '' },
+          data: { text: '', title: '', color: '#1f2937' },
           width: DEFAULT_NODE_WIDTH,
           height: DEFAULT_NODE_HEIGHT,
         },
@@ -575,7 +598,7 @@ export default function App() {
                 id: refId,
                 type: 'card',
                 position: { x: baseX + 300, y: baseY + idx * 100 },
-                data: { text: '', title: '' },
+                data: { text: '', title: '', color: '#1f2937' },
                 width: DEFAULT_NODE_WIDTH,
                 height: DEFAULT_NODE_HEIGHT,
               },
@@ -621,7 +644,11 @@ export default function App() {
       id: n.id,
       type: 'card',
       position: n.position || { x: 0, y: 0 },
-      data: { text: n.text || '', title: n.title || '' },
+      data: {
+        text: n.text || '',
+        title: n.title || '',
+        color: n.color || '#1f2937',
+      },
       width: n.width ?? DEFAULT_NODE_WIDTH,
       height: n.height ?? estimateNodeHeight(n.text || ''),
     }))
@@ -644,6 +671,7 @@ export default function App() {
         id: n.id,
         text: n.data.text || '',
         title: n.data.title || '',
+        color: n.data.color || '#1f2937',
         position: n.position,
         type: n.type || 'card',
         width: n.width,
@@ -707,7 +735,7 @@ export default function App() {
         id: n.id,
         type: 'card',
         position: n.position || { x: 0, y: 0 },
-        data: { text: n.text || '', title: n.title || '' },
+        data: { text: n.text || '', title: n.title || '', color: n.color || '#1f2937' },
         width: n.width ?? DEFAULT_NODE_WIDTH,
         height: n.height ?? estimateNodeHeight(n.text || ''),
       }))
@@ -806,6 +834,7 @@ export default function App() {
         id: n.id,
         text: n.data.text || '',
         title: n.data.title || '',
+        color: n.data.color || '#1f2937',
         position: n.position,
         type: n.type || 'card',
         width: n.width,
@@ -961,6 +990,30 @@ export default function App() {
           >
             <SpellCheck aria-hidden="true" />
           </button>
+          <div style={{ position: 'relative' }}>
+            <button
+              className="color-button"
+              type="button"
+              onClick={() => setShowColorPicker(c => !c)}
+              aria-label="Node color"
+              style={{
+                background:
+                  nodes.find(n => n.id === currentId)?.data.color || '#1f2937',
+              }}
+            />
+            {showColorPicker && (
+              <div className="color-picker">
+                {COLOR_OPTIONS.map(col => (
+                  <div
+                    key={col}
+                    className="color-swatch"
+                    style={{ background: col }}
+                    onClick={() => changeNodeColor(col)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
           <span className={`ai-loading${loadingAi ? ' show' : ''}`} aria-live="polite">
             Generating suggestions…
           </span>

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -4,6 +4,15 @@ import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer
 import '@reactflow/node-resizer/dist/style.css'
 import NodeEditorContext from './NodeEditorContext.js'
 
+function isLightColor(hex) {
+  if (!hex || typeof hex !== 'string' || hex[0] !== '#') return false
+  const r = parseInt(hex.slice(1, 3), 16)
+  const g = parseInt(hex.slice(3, 5), 16)
+  const b = parseInt(hex.slice(5, 7), 16)
+  const luminance = 0.299 * r + 0.587 * g + 0.114 * b
+  return luminance > 186
+}
+
 const NodeCard = memo(({ id, data, selected }) => {
   const { setNodes, getNodes } = useReactFlow()
   const { updateNodeText } = useContext(NodeEditorContext)
@@ -53,8 +62,14 @@ const NodeCard = memo(({ id, data, selected }) => {
     setNodes(ns => ns.map(n => (n.id === id ? { ...n, height } : n)))
   }
 
+  const bg = data.color || '#1f2937'
+  const textColor = isLightColor(bg) ? '#000' : 'var(--text)'
+
   return (
-    <div className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}>
+    <div
+      className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}
+      style={{ background: bg, color: textColor, '--card-bg': bg }}
+    >
       {invalidRef && <div className="invalid-dot" />}
       <div className="node-header">
         <span className="node-id">#{id}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -166,6 +166,37 @@ main {
   padding: 0.25rem 0;
   border-bottom: 1px solid var(--panel);
   background: var(--panel);
+  position: relative;
+}
+
+.color-button {
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: 3px;
+  cursor: pointer;
+}
+
+.color-picker {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 20px);
+  gap: 4px;
+  padding: 4px;
+  background: var(--panel);
+  border: 1px solid var(--panel);
+  border-radius: var(--radius);
+  z-index: 10;
+}
+
+.color-swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  cursor: pointer;
+  border: 1px solid #0003;
 }
 
 .ai-loading {
@@ -325,7 +356,7 @@ main {
   border-color: var(--accent);
 }
 .node-card.selected {
-  background: #3b4553;
+  box-shadow: 0 0 0 2px var(--accent);
 }
 .node-card.resizing {
   border-style: dashed;
@@ -351,7 +382,7 @@ main {
   white-space: nowrap;
 }
 .node-card .node-preview {
-  color: var(--text);
+  color: inherit;
   flex: 1;
   overflow: hidden;
   white-space: pre-wrap;
@@ -365,7 +396,11 @@ main {
   width: 100%;
   text-align: center;
   pointer-events: none;
-  background: linear-gradient(to bottom, rgba(31, 41, 55, 0) 0%, var(--card) 70%);
+  background: linear-gradient(
+    to bottom,
+    rgba(31, 41, 55, 0) 0%,
+    var(--card-bg, var(--card)) 70%
+  );
   color: var(--text-dim);
 }
 .node-card .node-textarea {
@@ -373,7 +408,7 @@ main {
   width: 100%;
   border: none;
   background: transparent;
-  color: var(--text);
+  color: inherit;
   font-family: 'Inter', sans-serif;
   font-size: inherit;
   resize: none;


### PR DESCRIPTION
## Summary
- add color picker tool in formatting toolbar
- allow nodes to store and export a color value
- compute text color based on background
- update styles for node colors and color picker UI
- mention color picker in documentation

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68513b76b1b4832fb792c351b22b2e16