### PR TITLE
Improve card height persistence

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -3,6 +3,7 @@ import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
 import NodeEditorContext from './NodeEditorContext.js'
+import { DEFAULT_NODE_HEIGHT } from './constants.js'
 
 function isLightColor(hex) {
   if (!hex || typeof hex !== 'string' || hex[0] !== '#') return false
@@ -22,6 +23,7 @@ const NodeCard = memo(({ id, data, selected }) => {
   const textRef = useRef(null)
   const previewRef = useRef(null)
   const prevSelectedRef = useRef(selected)
+  const previewHeight = useRef(DEFAULT_NODE_HEIGHT)
 
   useEffect(() => {
     if (selected && !prevSelectedRef.current) {
@@ -36,6 +38,34 @@ const NodeCard = memo(({ id, data, selected }) => {
       setOverflow(el.scrollHeight > el.clientHeight + 1)
     }
   }, [data.text, selected])
+
+  useEffect(() => {
+    if (!selected && previewRef.current) {
+      previewHeight.current = Math.min(
+        300,
+        Math.max(100, previewRef.current.scrollHeight + 16)
+      )
+      setNodes(ns =>
+        ns.map(n =>
+          n.id === id && n.height !== previewHeight.current
+            ? { ...n, height: previewHeight.current }
+            : n
+        )
+      )
+    }
+  }, [data.text, selected])
+
+  useEffect(() => {
+    if (selected) {
+      setNodes(ns =>
+        ns.map(n =>
+          n.id === id && n.height !== previewHeight.current
+            ? { ...n, height: previewHeight.current }
+            : n
+        )
+      )
+    }
+  }, [selected])
 
   useEffect(() => {
     const nodes = new Set(getNodes().map(n => n.id))


### PR DESCRIPTION
## Summary
- keep node height consistent when switching between preview and edit modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68528731cc70832f922f67c9471d0a38