### PR TITLE
feat: add theme switch and hide ai buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,56 @@
-# Choose Your Path Tool
+# Välj Väg Verktyg
 
-This project is now built with [Vite](https://vitejs.dev/) and [React](https://react.dev). The interactive graph is rendered using [React Flow](https://reactflow.dev/).
+A web-based editor for building choose-your-path stories as directed graphs. Nodes represent story sections and link to each other using Markdown references.
 
-## Development
+## Features
 
-Install dependencies and start the dev server:
+- Visual graph editor powered by React Flow
+- Markdown-based node content with automatic cross-node linking
+- Local project storage with import/export support
+- Playthrough mode to test the story from any node
+- Node background color customization
+- Dark and light themes with a header toggle
 
-```bash
-npm install
-npm run dev
-```
+## Getting Started
+
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Start the development server**
+   ```bash
+   npm run dev
+   ```
+   The app will be available at `http://localhost:5173/`.
 
 ## Building
 
-```
+Create a production build:
+
+```bash
 npm run build
 ```
 
-Project data can be saved locally. Tick the **Save** checkbox next to the project name to autosave the current story. Saved stories appear in the dropdown list in the header so you can quickly switch between them. Export and import options are available from the floating menu in the bottom right. The exported file contains the project name. Use **Export MD** in the header to download a Markdown file with all nodes. Nodes link to each other using references like `[#001]` inside the node text. The editor also understands bare references such as `#001` and will automatically convert them into the bracketed form.
+Preview the build locally:
 
-All rendered Markdown is sanitized with [DOMPurify](https://github.com/cure53/DOMPurify) to prevent unwanted HTML injection.
+```bash
+npm run preview
+```
 
-The graph view now provides zoom controls and a minimap for easier navigation of large node collections.
+## Usage
+
+- Click an empty area of the graph to create a new node.
+- Edit the node's title and body in the editor panel.
+- Use references like `#001` or Markdown links `[Continue → #002](#002)` to connect nodes.
+- Use the color square in the editor toolbar to change a node's background color.
+- Enable **Save** next to the project name to store the story locally.
+- Access export/import, playthrough, and other tools from the floating menu in the bottom-right corner.
+- Toggle between dark and light themes using the **Light/Dark Mode** button in the header.
+
+## Testing
+
+Run unit tests with:
+
+```bash
+npm test
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,6 +7,7 @@ This guide summarizes the built-in help information available at `help.html`.
 - Click an empty area of the graph to create a new node.
 - Edit the title and body directly inside the node.
 - Use references like `#001` or Markdown links such as `[Continue → #002](#002)` to connect nodes.
+- Use the color square in the editor toolbar to change a node's background color.
 
 ## Managing Projects
 
@@ -18,9 +19,14 @@ This guide summarizes the built-in help information available at `help.html`.
 
 Start a playthrough from the current node via **Play** in the floating menu.
 
+## Themes
+
+Switch between dark and light mode using the **Light/Dark Mode** button in the header.
+
+<!--
 ## AI Features
 
 - Configure API settings under **AI Settings**.
 - The cloud icon suggests how the story might continue.
 - The spell check icon proofreads the current text.
-- Use the color square to assign a background color to the current node.
+-->

--- a/help.html
+++ b/help.html
@@ -14,6 +14,7 @@
     <li>Click on an empty area of the graph to create a new node.</li>
     <li>Edit the title and body text directly inside the node.</li>
     <li>Type <code>#001</code> to create a reference or use Markdown links such as <code>[Continue → #002](#002)</code>.</li>
+    <li>Use the color square in the editor toolbar to change a node's background color.</li>
   </ul>
   <h2>Managing Projects</h2>
   <ul>
@@ -25,12 +26,17 @@
   <ul>
     <li>Choose <strong>Play</strong> from the floating menu to read through the story starting from the current node.</li>
   </ul>
+  <h2>Themes</h2>
+  <ul>
+    <li>Toggle between dark and light mode using the button in the header.</li>
+  </ul>
+  <!--
   <h2>AI Features</h2>
   <ul>
     <li>Configure API settings under <strong>AI Settings</strong> in the floating menu.</li>
     <li>The cloud icon generates suggestions for how the story might continue.</li>
     <li>The spell check icon proofreads the current text.</li>
-    <li>The color square lets you change the background of the selected node.</li>
   </ul>
+  -->
 </body>
 </html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,11 +6,10 @@ import {
   RotateCw,
   Download,
   Upload,
-  Cloud,
-  SpellCheck,
-  Settings,
   ChevronLeft,
-  ChevronRight
+  ChevronRight,
+  Sun,
+  Moon
 } from 'lucide-react'
 import ReactFlow, {
   applyNodeChanges,
@@ -28,9 +27,10 @@ import NodeEditorContext from './NodeEditorContext.js'
 import Playthrough from './Playthrough.jsx'
 import LinearView from './LinearView.jsx'
 import AiSettingsModal from './AiSettingsModal.jsx'
-import AiSuggestionsPanel from './AiSuggestionsPanel.jsx'
-import { useAiSettings, getSuggestions, proofreadText } from './useAi.js'
-import AiProofreadPanel from './AiProofreadPanel.jsx'
+// import AiSuggestionsPanel from './AiSuggestionsPanel.jsx'
+// import { getSuggestions, proofreadText } from './useAi.js'
+import { useAiSettings } from './useAi.js'
+// import AiProofreadPanel from './AiProofreadPanel.jsx'
 import Button from './Button.jsx'
 import FloatingMenu from './FloatingMenu.jsx'
 import NewProjectModal from './NewProjectModal.jsx'
@@ -112,21 +112,22 @@ export default function App() {
     return saved ? JSON.parse(saved) : false
   })
   const [aiSettings, setAiSettings] = useAiSettings()
-  const [suggestions, setSuggestions] = useState([])
+  // const [suggestions, setSuggestions] = useState([])
   const [showAiSettings, setShowAiSettings] = useState(false)
-  const [showSuggestions, setShowSuggestions] = useState(false)
-  const [proofreadResult, setProofreadResult] = useState(null)
-  const [showProofread, setShowProofread] = useState(false)
+  // const [showSuggestions, setShowSuggestions] = useState(false)
+  // const [proofreadResult, setProofreadResult] = useState(null)
+  // const [showProofread, setShowProofread] = useState(false)
   const [showColorPicker, setShowColorPicker] = useState(false)
   const [showNewProject, setShowNewProject] = useState(false)
   const [editorCollapsed, setEditorCollapsed] = useState(() =>
     window.innerWidth < 768
   )
-  const [loadingAi, setLoadingAi] = useState(false)
+  // const [loadingAi, setLoadingAi] = useState(false)
   const [fontSize, setFontSize] = useState(() => {
     const stored = localStorage.getItem('cyoa-font-size')
     return stored ? Number(stored) : 14
   })
+  const [theme, setTheme] = useState(() => localStorage.getItem('vv-theme') || 'dark')
   const textRef = useRef(null)
   const importRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
@@ -137,6 +138,11 @@ export default function App() {
     document.documentElement.style.setProperty('--font-size', `${fontSize}px`)
     localStorage.setItem('cyoa-font-size', String(fontSize))
   }, [fontSize])
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme)
+    localStorage.setItem('vv-theme', theme)
+  }, [theme])
 
   // Restore previous session from localStorage on initial load
   useEffect(() => {
@@ -296,6 +302,7 @@ export default function App() {
     })
   }
 
+  /*
   const fetchAiSuggestions = async () => {
     setLoadingAi(true)
     const result = await getSuggestions(nodes, currentId, aiSettings)
@@ -333,6 +340,7 @@ export default function App() {
     })
     setShowSuggestions(false)
   }
+  */
 
   const changeNodeColor = color => {
     if (!currentId) return
@@ -930,7 +938,14 @@ export default function App() {
         <Button variant="ghost" onClick={() => setFontSize(f => f + 1)}>
           A+
         </Button>
-        
+        <Button
+          variant="ghost"
+          icon={theme === 'dark' ? Sun : Moon}
+          onClick={() => setTheme(t => (t === 'dark' ? 'light' : 'dark'))}
+        >
+          {theme === 'dark' ? 'Light' : 'Dark'} Mode
+        </Button>
+
       </header>
       <main style={{ position: 'relative' }}>
         <div id="graph">
@@ -982,6 +997,7 @@ export default function App() {
           <button className="btn ghost" type="button" onClick={insertNextNodeNumber} aria-label="Next node number">
             <Plus aria-hidden="true" />
           </button>
+          {/*
           <button
             className="btn ghost"
             type="button"
@@ -998,6 +1014,7 @@ export default function App() {
           >
             <SpellCheck aria-hidden="true" />
           </button>
+          */}
           <div style={{ position: 'relative' }}>
             <button
               className="color-button"
@@ -1022,9 +1039,7 @@ export default function App() {
               </div>
             )}
           </div>
-          <span className={`ai-loading${loadingAi ? ' show' : ''}`} aria-live="polite">
-            Generating suggestions…
-          </span>
+          {/* AI loading indicator removed */}
           {/* Settings button moved to header */}
         </div>
           <input
@@ -1067,6 +1082,7 @@ export default function App() {
           onClose={() => setShowAiSettings(false)}
         />
       )}
+      {/*
       {showSuggestions && (
         <AiSuggestionsPanel
           suggestions={suggestions}
@@ -1082,6 +1098,7 @@ export default function App() {
           onClose={() => setShowProofread(false)}
         />
       )}
+      */}
       {showNewProject && (
         <NewProjectModal
           onConfirm={startNewProject}
@@ -1092,7 +1109,7 @@ export default function App() {
         onExport={exportProject}
         onImport={() => importRef.current?.click()}
         onShowSettings={openSettings}
-        onShowAiSettings={() => setShowAiSettings(true)}
+        // onShowAiSettings={() => setShowAiSettings(true)}
         onExportMd={exportMarkdown}
         onLinearView={openLinearView}
         onPlaythrough={startPlaythrough}

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -17,7 +17,7 @@ export default function FloatingMenu({
   onExport,
   onImport,
   onShowSettings,
-  onShowAiSettings,
+  // onShowAiSettings,
   onExportMd,
   onLinearView,
   onPlaythrough,
@@ -101,12 +101,15 @@ export default function FloatingMenu({
               >
                 <span className="flex items-center gap-2"><Settings className="h-4 w-4" />Settings</span>
               </button>
+              {/* AI Settings button temporarily disabled */}
+              {/*
               <button
                 className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
                 onClick={onShowAiSettings}
               >
                 <span className="flex items-center gap-2"><Settings className="h-4 w-4" />AI Settings</span>
               </button>
+              */}
               {onHelp && (
                 <button
                   className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"

--- a/src/index.css
+++ b/src/index.css
@@ -199,18 +199,6 @@ main {
   border: 1px solid #0003;
 }
 
-.ai-loading {
-  margin-left: 0.5rem;
-  font-size: 0.8rem;
-  opacity: 0;
-  transition: opacity 0.3s;
-  align-self: center;
-}
-
-.ai-loading.show {
-  opacity: 1;
-}
-
 .reset-btn {
   margin-left: 0.5rem;
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -1,16 +1,30 @@
 :root {
+  --radius: 6px;
+  --gap: 0.5rem;
+  --font-size: 14px;
+  --accent: #3b82f6;
+}
+
+[data-theme="light"] {
+  --bg: #f9fafb;
+  --panel: #f3f4f6;
+  --card: #e5e7eb;
+  --text: #111827;
+  --text-dim: #6b7280;
+  --btn: #e5e7eb;
+  --btn-hover: #d1d5db;
+  --modal-bg: #ffffff;
+}
+
+[data-theme="dark"] {
   --bg: #0d1117;
   --panel: #161b22;
   --card: #1f2937;
-  --accent: #3b82f6;
   --text: #f3f4f6;
   --text-dim: #9ca3af;
-  --radius: 6px;
-  --gap: 0.5rem;
   --btn: #4a5568;
   --btn-hover: #5b667a;
-  --font-size: 14px;
-  --modal-bg: #222;
+  --modal-bg: #222222;
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- add dark/light mode toggle and supporting theme variables
- hide AI-related buttons and menu items for later use
- document application features and usage in a new README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62921b144832fa05c662503840861