### PR TITLE
Fix node text contrast in light mode

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -93,12 +93,14 @@ const NodeCard = memo(({ id, data, selected }) => {
   }
 
   const bg = data.color || '#1f2937'
-  const textColor = isLightColor(bg) ? '#000' : 'var(--text)'
+  const lightBg = isLightColor(bg)
+  const textColor = lightBg ? '#111827' : '#f3f4f6'
+  const dimColor = lightBg ? '#6b7280' : '#9ca3af'
 
   return (
     <div
       className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}
-      style={{ background: bg, color: textColor, '--card-bg': bg }}
+      style={{ background: bg, color: textColor, '--card-bg': bg, '--text-dim': dimColor }}
     >
       {invalidRef && <div className="invalid-dot" />}
       <div className="node-header">


### PR DESCRIPTION
## Summary
- adjust NodeCard text colors based on background brightness for legibility

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a63d0b98b8832f9a0daf3f39319a0c