### PR TITLE
Fix shrinking nodes on selection

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -3,7 +3,7 @@ import { Handle, Position, useReactFlow } from 'reactflow'
 import { NodeResizeControl, ResizeControlVariant } from '@reactflow/node-resizer'
 import '@reactflow/node-resizer/dist/style.css'
 import NodeEditorContext from './NodeEditorContext.ts'
-import { DEFAULT_NODE_HEIGHT } from './constants.js'
+import { DEFAULT_NODE_HEIGHT, DEFAULT_NODE_WIDTH } from './constants.js'
 
 function isLightColor(hex) {
   if (!hex || typeof hex !== 'string' || hex[0] !== '#') return false
@@ -24,6 +24,7 @@ const NodeCard = memo(({ id, data, selected }) => {
   const previewRef = useRef(null)
   const prevSelectedRef = useRef(selected)
   const previewHeight = useRef(DEFAULT_NODE_HEIGHT)
+  const previewWidth = useRef(DEFAULT_NODE_WIDTH)
 
   useEffect(() => {
     if (selected && !prevSelectedRef.current) {
@@ -41,14 +42,24 @@ const NodeCard = memo(({ id, data, selected }) => {
 
   useEffect(() => {
     if (!selected && previewRef.current) {
+      const width = Math.min(
+        400,
+        Math.max(180, previewRef.current.parentElement.offsetWidth)
+      )
+      previewWidth.current = width
       previewHeight.current = Math.min(
         300,
         Math.max(100, previewRef.current.scrollHeight + 16)
       )
       setNodes(ns =>
         ns.map(n =>
-          n.id === id && n.height !== previewHeight.current
-            ? { ...n, height: previewHeight.current }
+          n.id === id &&
+          (n.height !== previewHeight.current || n.width !== previewWidth.current)
+            ? {
+                ...n,
+                height: previewHeight.current,
+                width: previewWidth.current,
+              }
             : n
         )
       )
@@ -59,8 +70,13 @@ const NodeCard = memo(({ id, data, selected }) => {
     if (selected) {
       setNodes(ns =>
         ns.map(n =>
-          n.id === id && n.height !== previewHeight.current
-            ? { ...n, height: previewHeight.current }
+          n.id === id &&
+          (n.height !== previewHeight.current || n.width !== previewWidth.current)
+            ? {
+                ...n,
+                height: previewHeight.current,
+                width: previewWidth.current,
+              }
             : n
         )
       )

--- a/src/__tests__/NodeSize.test.jsx
+++ b/src/__tests__/NodeSize.test.jsx
@@ -3,7 +3,15 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import ReactFlow from 'reactflow';
+import ReactFlow, { ReactFlowProvider } from 'reactflow';
+
+jest.mock('@reactflow/node-resizer', () => ({
+  NodeResizeControl: () => null,
+  ResizeControlVariant: { Handle: 'handle' },
+}));
+
+import NodeCard from '../NodeCard.jsx';
+import NodeEditorContext from '../NodeEditorContext.ts';
 
 // simple ResizeObserver mock for ReactFlow
 global.ResizeObserver = class {
@@ -12,15 +20,27 @@ global.ResizeObserver = class {
   disconnect() {}
 };
 
-const nodes = [{ id: '1', position: { x: 0, y: 0 }, data: {} }];
+const longText = `Lorem ipsum dolor sit amet, consectetur adipiscing elit. ` +
+  `Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;
+const nodes = [
+  { id: '1', type: 'card', position: { x: 0, y: 0 }, data: { text: longText } },
+];
 
 it('keeps node dimensions after click', () => {
   const { container } = render(
-    <div style={{ width: 500, height: 500 }}>
-      <ReactFlow nodes={nodes} edges={[]} />
-    </div>
+    <NodeEditorContext.Provider value={{ updateNodeText: () => {} }}>
+      <ReactFlowProvider>
+        <div style={{ width: 500, height: 500 }}>
+          <ReactFlow
+            nodes={nodes}
+            edges={[]}
+            nodeTypes={{ card: NodeCard }}
+          />
+        </div>
+      </ReactFlowProvider>
+    </NodeEditorContext.Provider>
   );
-  const node = container.querySelector('.react-flow__node');
+  const node = container.querySelector('.react-flow__node-card');
   expect(node).toBeInTheDocument();
   const { width, height } = getComputedStyle(node);
   fireEvent.click(node);


### PR DESCRIPTION
## Summary
- keep nodes at measured width and height when selected so they don't snap small
- test that node dimensions stay the same after a click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a641cb6eec832f87f097be698a8fb6