### PR TITLE
Add project dropdown and streamline menus

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react'
+import { useState, useCallback, useMemo, useRef, useEffect, Fragment } from 'react'
 import {
   Plus,
   Trash2,
@@ -6,11 +6,15 @@ import {
   RotateCw,
   Download,
   Upload,
+  FilePlus,
+  FileText,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Sun,
   Moon
 } from 'lucide-react'
+import { Popover, Transition } from '@headlessui/react'
 import ReactFlow, {
   applyNodeChanges,
   applyEdgeChanges,
@@ -859,6 +863,70 @@ export default function App() {
           />
           Save
         </label>
+        <Popover className="relative">
+          {({ open }) => (
+            <>
+              <Popover.Button className="btn ghost flex items-center gap-1" title="Project actions">
+                Project <ChevronDown className="h-4 w-4" />
+              </Popover.Button>
+              <Transition
+                as={Fragment}
+                show={open}
+                enter="transition ease-out duration-200"
+                enterFrom="opacity-0 translate-y-1"
+                enterTo="opacity-100 translate-y-0"
+                leave="transition ease-in duration-150"
+                leaveFrom="opacity-100 translate-y-0"
+                leaveTo="opacity-0 translate-y-1"
+              >
+                <Popover.Panel className="absolute z-10 mt-2 w-40 rounded bg-[var(--panel)] p-2 text-sm text-[var(--text)] shadow-lg">
+                  <div className="flex flex-col gap-1">
+                    <button
+                      className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                      onClick={confirmNewProject}
+                      title="New project"
+                    >
+                      <span className="flex items-center gap-2">
+                        <FilePlus className="h-4 w-4" />
+                        New project
+                      </span>
+                    </button>
+                    <button
+                      className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                      onClick={() => importRef.current?.click()}
+                      title="Import"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Upload className="h-4 w-4" />
+                        Import
+                      </span>
+                    </button>
+                    <button
+                      className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                      onClick={exportProject}
+                      title="Export"
+                    >
+                      <span className="flex items-center gap-2">
+                        <Download className="h-4 w-4" />
+                        Export
+                      </span>
+                    </button>
+                    <button
+                      className="rounded px-3 py-1 text-left hover:bg-[var(--card)]"
+                      onClick={exportMarkdown}
+                      title="Export MD"
+                    >
+                      <span className="flex items-center gap-2">
+                        <FileText className="h-4 w-4" />
+                        Export MD
+                      </span>
+                    </button>
+                  </div>
+                </Popover.Panel>
+              </Transition>
+            </>
+          )}
+        </Popover>
         <select
           id="projectList"
           value={projectId}
@@ -1104,16 +1172,12 @@ export default function App() {
         />
       )}
       <FloatingMenu
-        onExport={exportProject}
-        onImport={() => importRef.current?.click()}
         onShowSettings={openSettings}
         // onShowAiSettings={() => setShowAiSettings(true)}
-        onExportMd={exportMarkdown}
         onLinearView={openLinearView}
         onPlaythrough={startPlaythrough}
         onAutoLayout={!showModal && !showPlay ? handleAutoLayout : undefined}
         onHelp={openHelp}
-        onNewProject={confirmNewProject}
       />
     </>
   )

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -2,27 +2,14 @@ import { Fragment } from 'react'
 import { Popover, Transition } from '@headlessui/react'
 import {
   Menu,
-  Upload,
-  Download,
   Settings,
   HelpCircle,
-  FileText,
-  FilePlus,
   List,
   Play,
   LayoutGrid,
 } from 'lucide-react'
 
 const sectionConfig = [
-  {
-    title: 'Project',
-    items: [
-      { label: 'New project', icon: FilePlus, action: 'onNewProject' },
-      { label: 'Import', icon: Upload, action: 'onImport' },
-      { label: 'Export', icon: Download, action: 'onExport' },
-      { label: 'Export MD', icon: FileText, action: 'onExportMd' },
-    ],
-  },
   {
     title: 'View',
     items: [
@@ -44,27 +31,19 @@ const sectionConfig = [
 ]
 
 export default function FloatingMenu({
-  onExport,
-  onImport,
   onShowSettings,
   // onShowAiSettings,
-  onExportMd,
   onLinearView,
   onPlaythrough,
   onAutoLayout,
   onHelp,
-  onNewProject,
 }) {
   const propMap = {
-    onExport,
-    onImport,
     onShowSettings,
-    onExportMd,
     onLinearView,
     onPlaythrough,
     onAutoLayout,
     onHelp,
-    onNewProject,
   }
 
   const sections = sectionConfig


### PR DESCRIPTION
## Summary
- Add project actions dropdown to header for creating, importing, and exporting projects
- Remove project buttons from floating menu, keeping only view/tools/help actions

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a6bd119f04832f8a379c32fb6085d4