### PR TITLE
Fix header menu clipping dropdown

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -18,11 +18,10 @@ body {
 
 header {
   display: flex;
+  flex-wrap: wrap;
   gap: var(--gap);
   padding: var(--gap);
   border-bottom: 1px solid var(--panel);
-  overflow-x: auto;
-  white-space: nowrap;
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- prevent header overflow from hiding menu items by allowing wrapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6bfba9d44832f892f8137cc4276c3