### PR TITLE
Prevent pane clicks from interrupting node resizing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,6 +127,7 @@ export default function App() {
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
   const undoStack = useRef([])
   const redoStack = useRef([])
+  const resizingRef = useRef(false)
 
   useEffect(() => {
     document.documentElement.style.setProperty('--font-size', `${fontSize}px`)
@@ -541,6 +542,7 @@ export default function App() {
   }
 
   const onPaneClick = () => {
+    if (resizingRef.current) return
     setCurrentId(null)
     setText('')
     setTitle('')
@@ -972,7 +974,7 @@ export default function App() {
       </header>
       <main style={{ position: 'relative' }}>
         <div id="graph">
-          <NodeEditorContext.Provider value={{ updateNodeText }}>
+          <NodeEditorContext.Provider value={{ updateNodeText, resizingRef }}>
           <ReactFlow
             style={{ width: '100%', height: '100%' }}
             nodes={nodes}

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -16,7 +16,7 @@ function isLightColor(hex) {
 
 const NodeCard = memo(({ id, data, selected }) => {
   const { setNodes, getNodes } = useReactFlow()
-  const { updateNodeText } = useContext(NodeEditorContext)
+  const { updateNodeText, resizingRef } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
   const [overflow, setOverflow] = useState(false)
   const [invalidRef, setInvalidRef] = useState(false)
@@ -99,6 +99,9 @@ const NodeCard = memo(({ id, data, selected }) => {
     setNodes(ns =>
       ns.map(n => (n.id === id ? { ...n, width, height } : n))
     )
+    setTimeout(() => {
+      if (resizingRef) resizingRef.current = false
+    }, 0)
   }
 
   const autoResize = () => {
@@ -117,6 +120,8 @@ const NodeCard = memo(({ id, data, selected }) => {
     <div
       className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}
       style={{ background: bg, color: textColor, '--card-bg': bg, '--text-dim': dimColor }}
+      onPointerDown={e => e.stopPropagation()}
+      onClick={e => e.stopPropagation()}
     >
       {invalidRef && <div className="invalid-dot" />}
       <div className="node-header">
@@ -152,7 +157,16 @@ const NodeCard = memo(({ id, data, selected }) => {
         maxWidth={400}
         maxHeight={300}
         className="resize-handle"
-        onResizeStart={() => setResizing(true)}
+        handleStyle={{
+          width: 14,
+          height: 14,
+          borderRadius: 6,
+          border: '1px solid rgba(0,0,0,.25)',
+        }}
+        onResizeStart={() => {
+          setResizing(true)
+          if (resizingRef) resizingRef.current = true
+        }}
         onResizeEnd={handleResizeEnd}
         onDoubleClick={autoResize}
       />

--- a/src/NodeEditorContext.ts
+++ b/src/NodeEditorContext.ts
@@ -1,11 +1,17 @@
-import { createContext } from 'react'
+import { createContext, MutableRefObject } from 'react'
 
 export interface NodeEditorContextType {
   updateNodeText: (id: string, text: string) => void
+  /**
+   * Tracks whether a node is currently being resized. Used to suppress pane
+   * clicks that would otherwise clear selection while a resize is in progress.
+   */
+  resizingRef: MutableRefObject<boolean>
 }
 
 const NodeEditorContext = createContext<NodeEditorContextType>({
   updateNodeText: () => {},
+  resizingRef: { current: false },
 })
 
 export default NodeEditorContext

--- a/src/__tests__/NodeSize.test.jsx
+++ b/src/__tests__/NodeSize.test.jsx
@@ -29,7 +29,7 @@ const nodes = [
 
 it('keeps node dimensions after click', () => {
   const { container } = render(
-    <NodeEditorContext.Provider value={{ updateNodeText: () => {} }}>
+    <NodeEditorContext.Provider value={{ updateNodeText: () => {}, resizingRef: { current: false } }}>
       <ReactFlowProvider>
         <div style={{ width: 500, height: 500 }}>
           <ReactFlow


### PR DESCRIPTION
## Summary
- Track resizing state via context and ignore pane clicks while resizing
- Stop event propagation within nodes and enlarge resize handle
- Adjust tests for new resizing context

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6c38808d8832f907d77aa06a77007