### PR TITLE
Fix node selection and restore resizing

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -95,8 +95,6 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
         height,
         boxSizing: 'border-box',
       }}
-      onPointerDown={e => e.stopPropagation()}
-      onClick={e => e.stopPropagation()}
     >
       {invalidRef && <div className="invalid-dot" />}
       <div className="node-header">
@@ -112,6 +110,8 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
           <textarea
             ref={textRef}
             className="node-textarea"
+            onPointerDown={e => e.stopPropagation()}
+            onClick={e => e.stopPropagation()}
             value={data.text}
             onChange={e => {
               let value = e.target.value


### PR DESCRIPTION
## Summary
- allow React Flow to receive node clicks so side editor stays in sync
- stop text editor pointer events to keep node selection while editing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7354c8118832f81d74c8c0279f615