### PR TITLE
chore: remove unused resize handle style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -439,17 +439,6 @@ main {
   border-radius: 50%;
 }
 
-.resize-handle {
-  position: absolute;
-  right: 4px;
-  bottom: 4px;
-  width: 12px;
-  height: 12px;
-  cursor: nwse-resize;
-  background: var(--accent);
-  border-radius: 2px;
-  opacity: 0.5;
-}
 
 #settingsButton {
   margin-left: auto;


### PR DESCRIPTION
## Summary
- remove unused `.resize-handle` CSS rule from stylesheet

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7798c5994832fb6700eb26ea9d321