### PR TITLE
test: simplify node resizer mock

### DIFF
--- a/src/__tests__/NodeSize.test.jsx
+++ b/src/__tests__/NodeSize.test.jsx
@@ -6,9 +6,7 @@ import '@testing-library/jest-dom';
 import ReactFlow, { ReactFlowProvider } from 'reactflow';
 import { jest } from '@jest/globals';
 
-jest.mock('@reactflow/node-resizer', () => ({
-  NodeResizer: () => null,
-}));
+jest.mock('@reactflow/node-resizer', () => ({ NodeResizer: () => null }));
 
 import NodeCard from '../NodeCard.jsx';
 import NodeEditorContext from '../NodeEditorContext.ts';


### PR DESCRIPTION
## Summary
- adjust NodeSize test to mock `NodeResizer`

## Testing
- `npm test -- src/__tests__/NodeSize.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68a77c93322c832f8bea46131acd58b2