### PR TITLE
Remove obsolete CSS resize rule

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -414,7 +414,6 @@ main {
   color: inherit;
   font-family: 'Inter', sans-serif;
   font-size: inherit;
-  resize: none;
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- remove `resize` property from node textarea styles to rely on NodeResizer

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a77ec23618832f908815dd7cdf9320