### PR TITLE
Fix node content sizing with NodeResizer

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -91,9 +91,9 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
         color: textColor,
         '--card-bg': bg,
         '--text-dim': dimColor,
-        width,
-        height,
         boxSizing: 'border-box',
+        width: '100%',
+        height: '100%',
       }}
     >
       {invalidRef && <div className="invalid-dot" />}


### PR DESCRIPTION
## Summary
- Ensure NodeCard content fills resized node container

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a78a4341cc832fbd0463c4da478636