### PR TITLE
Disable native textarea resize

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -417,6 +417,7 @@ main {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
   overflow-y: auto;
+  resize: none;
   scrollbar-width: none;
   -ms-overflow-style: none;
 }


### PR DESCRIPTION
## Summary
- hide the browser's textarea resize handle so NodeResizer controls sizing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8107e113c832fa8de78789494ce94