### PR TITLE
Persist node dimensions via style in project storage

### DIFF
--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -54,7 +54,12 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
     setNodes(ns =>
       ns.map(n =>
         n.id === id
-          ? { ...n, width: w, height: h, data: { ...n.data, size: { width: w, height: h } } }
+          ? {
+              ...n,
+              width: w,
+              height: h,
+              style: { ...(n.style || {}), width: w, height: h },
+            }
           : n
       )
     )
@@ -71,7 +76,11 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
     setNodes(ns =>
       ns.map(n =>
         n.id === id
-          ? { ...n, height: h, data: { ...n.data, size: { width: n.width, height: h } } }
+          ? {
+              ...n,
+              height: h,
+              style: { ...(n.style || {}), width: n.width, height: h },
+            }
           : n
       )
     )

--- a/src/__tests__/ProjectStorage.test.jsx
+++ b/src/__tests__/ProjectStorage.test.jsx
@@ -1,0 +1,76 @@
+/* eslint-env jest */
+/* global describe, it, expect */
+import { renderHook } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import useProjectStorage from '../useProjectStorage.js'
+
+describe('useProjectStorage persistence', () => {
+  it('keeps resized node size after reload', () => {
+    const store = {}
+    const mockStorage = {
+      getItem: key => (key in store ? store[key] : null),
+      setItem: (key, value) => {
+        store[key] = value
+      },
+      removeItem: key => {
+        delete store[key]
+      },
+    }
+    Object.defineProperty(window, 'localStorage', { value: mockStorage, writable: true })
+
+    const initialNode = {
+      id: '1',
+      type: 'card',
+      position: { x: 0, y: 0 },
+      data: { text: '' },
+      width: 100,
+      height: 100,
+      style: { width: 100, height: 100 },
+    }
+
+    const noop = () => {}
+    const { rerender, unmount } = renderHook(
+      ({ nodes }) =>
+        useProjectStorage({
+          nodes,
+          nextId: 2,
+          projectName: '',
+          autoSave: false,
+          setNodes: noop,
+          setNextId: noop,
+          setProjectName: noop,
+        }),
+      { initialProps: { nodes: [initialNode] } }
+    )
+
+    const resized = {
+      ...initialNode,
+      width: 200,
+      height: 150,
+      style: { width: 200, height: 150 },
+    }
+    rerender({ nodes: [resized] })
+    unmount()
+
+    const setNodesLoaded = jest.fn()
+    renderHook(() =>
+      useProjectStorage({
+        nodes: [],
+        nextId: 2,
+        projectName: '',
+        autoSave: false,
+        setNodes: setNodesLoaded,
+        setNextId: noop,
+        setProjectName: noop,
+      })
+    )
+
+    expect(setNodesLoaded).toHaveBeenCalledWith([
+      expect.objectContaining({
+        width: 200,
+        height: 150,
+        style: { width: 200, height: 150 },
+      }),
+    ])
+  })
+})

--- a/src/useProjectStorage.js
+++ b/src/useProjectStorage.js
@@ -59,14 +59,19 @@ export default function useProjectStorage({
     }
     if (data) {
       try {
-        const loaded = (data.nodes || []).map(n => ({
-          id: n.id,
-          type: 'card',
-          position: n.position || { x: 0, y: 0 },
-          data: { text: n.text || '', title: n.title || '', color: n.color || '#1f2937' },
-          width: n.width ?? DEFAULT_NODE_WIDTH,
-          height: n.height ?? estimateNodeHeight(n.text || ''),
-        }))
+        const loaded = (data.nodes || []).map(n => {
+          const w = n.style?.width ?? n.width ?? DEFAULT_NODE_WIDTH
+          const h = n.style?.height ?? n.height ?? estimateNodeHeight(n.text || '')
+          return {
+            id: n.id,
+            type: 'card',
+            position: n.position || { x: 0, y: 0 },
+            data: { text: n.text || '', title: n.title || '', color: n.color || '#1f2937' },
+            width: w,
+            height: h,
+            style: { width: w, height: h },
+          }
+        })
         setNodes(loaded)
         setNextId(data.nextNodeId || 1)
         setProjectName(data.projectName || '')
@@ -89,6 +94,10 @@ export default function useProjectStorage({
         type: n.type || 'card',
         width: n.width,
         height: n.height,
+        style: {
+          width: n.style?.width ?? n.width,
+          height: n.style?.height ?? n.height,
+        },
       })),
     }
     try {


### PR DESCRIPTION
## Summary
- track visual width/height in NodeCard style on resize or auto-resize
- store style dimensions in project save data and restore on load
- add Jest test ensuring resized node size persists via localStorage

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a850c4191c832f94f02055bb3016b5