### PR TITLE
feat: add nodes-to-html conversion

### DIFF
--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -1,0 +1,27 @@
+import type { Node } from 'reactflow'
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+export function convertNodesToHtml(nodes: Node[]): string {
+  return nodes
+    .map(n => {
+      const title = escapeHtml(n.data?.title || '')
+      const header = `<h2 data-node-id="${n.id}">#${n.id} ${title}</h2>`
+      const paragraphs = (n.data?.text || '')
+        .split(/\n+/)
+        .filter(p => p.length > 0)
+        .map(p => `<p>${escapeHtml(p)}</p>`)
+        .join('')
+      return `${header}${paragraphs}`
+    })
+    .join('')
+}
+
+export default convertNodesToHtml


### PR DESCRIPTION
## Summary
- add utility to convert nodes into HTML headings and paragraphs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ccafd878832fa3b23714debd87f1