### PR TITLE
Add HTML to nodes parser utility

### DIFF
--- a/src/__tests__/LinearConversion.test.ts
+++ b/src/__tests__/LinearConversion.test.ts
@@ -1,0 +1,32 @@
+import { parseHtmlToNodes } from '../utils/linearConversion.ts'
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '../constants.js'
+import type { Node } from 'reactflow'
+
+describe('parseHtmlToNodes', () => {
+  test('parses html and preserves existing nodes', () => {
+    const html = `\
+<h2 data-node-id="001">#001 Start</h2>
+<p>First line</p>
+<h2 data-node-id="002">#002 Next</h2>
+<p>Second</p>`
+    const prev: Node[] = [{
+      id: '001',
+      type: 'card',
+      position: { x: 5, y: 10 },
+      data: { title: 'Old', text: 'Old text', color: '#000' },
+      width: 111,
+      height: 222,
+    } as any]
+    const nodes = parseHtmlToNodes(html, prev)
+    expect(nodes).toHaveLength(2)
+    expect(nodes[0].position).toEqual({ x: 5, y: 10 })
+    expect(nodes[0].data.title).toBe('Start')
+    expect(nodes[0].data.text).toBe('First line')
+    expect(nodes[0].width).toBe(111)
+    expect(nodes[1].id).toBe('002')
+    expect(nodes[1].data.title).toBe('Next')
+    expect(nodes[1].data.text).toBe('Second')
+    expect(nodes[1].width).toBe(DEFAULT_NODE_WIDTH)
+    expect(nodes[1].position).toEqual({ x: 0, y: DEFAULT_NODE_HEIGHT })
+  })
+})

--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -1,4 +1,5 @@
 import type { Node } from 'reactflow'
+import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '../constants.js'
 
 function escapeHtml(str: string): string {
   return str
@@ -22,6 +23,39 @@ export function convertNodesToHtml(nodes: Node[]): string {
       return `${header}${paragraphs}`
     })
     .join('')
+}
+
+export function parseHtmlToNodes(html: string, prevNodes: Node[] = []): Node[] {
+  const template = document.createElement('template')
+  template.innerHTML = html
+  const headers = Array.from(template.content.querySelectorAll('h2[data-node-id]'))
+  const prevMap = new Map(prevNodes.map(n => [n.id, n]))
+
+  return headers.map((h2, index) => {
+    const id = h2.getAttribute('data-node-id') || ''
+    const title = (h2.textContent || '').replace(/^#\d+\s*/, '').trim()
+    const paragraphs: string[] = []
+    let el: Element | null = h2.nextElementSibling
+    while (el && !(el.tagName.toLowerCase() === 'h2' && el.hasAttribute('data-node-id'))) {
+      if (el.tagName.toLowerCase() === 'p') {
+        paragraphs.push(el.textContent || '')
+      }
+      el = el.nextElementSibling
+    }
+    const text = paragraphs.join('\n')
+    const prev = prevMap.get(id)
+    if (prev) {
+      return { ...prev, data: { ...prev.data, title, text } }
+    }
+    return {
+      id,
+      type: 'card',
+      position: { x: 0, y: index * DEFAULT_NODE_HEIGHT },
+      data: { title, text, color: '#1f2937' },
+      width: DEFAULT_NODE_WIDTH,
+      height: DEFAULT_NODE_HEIGHT,
+    }
+  })
 }
 
 export default convertNodesToHtml


### PR DESCRIPTION
## Summary
- add `parseHtmlToNodes` to convert HTML back into node objects
- test HTML to node parsing to ensure metadata preservation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cda375c8832f94f908dd7361304e