### PR TITLE
feat: add arrow reference link extension

### DIFF
--- a/src/ArrowLink.ts
+++ b/src/ArrowLink.ts
@@ -1,0 +1,75 @@
+import { Node, mergeAttributes, nodeInputRule, nodePasteRule } from '@tiptap/core'
+
+// ArrowLink is an inline atom that renders references like "→ [#123]" as links
+// pointing to the referenced node id.
+const ArrowLink = Node.create({
+  name: 'arrowLink',
+  inline: true,
+  group: 'inline',
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return {
+      id: {
+        default: null,
+        parseHTML: element => element.getAttribute('data-arrow-id'),
+        renderHTML: attributes => ({
+          'data-arrow-id': attributes.id,
+          href: `#${attributes.id}`,
+          class: 'arrow-link',
+        }),
+      },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: 'a[data-arrow-id]' }]
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const id = HTMLAttributes['data-arrow-id'] || HTMLAttributes.id
+    return ['a', mergeAttributes(HTMLAttributes), `\u2192 #${id}`]
+  },
+
+  addInputRules() {
+    return [
+      nodeInputRule({
+        find: /\u2192\s\[#(\d{3})\]$/, // → [#123]
+        type: this.type,
+        getAttributes: match => ({ id: match[1] }),
+      }),
+    ]
+  },
+
+  addPasteRules() {
+    return [
+      nodePasteRule({
+        find: /\u2192\s\[#(\d{3})\]/g,
+        type: this.type,
+        getAttributes: match => ({ id: match[1] }),
+      }),
+    ]
+  },
+
+  addStorage() {
+    return {
+      markdown: {
+        serialize: (state, node) => {
+          state.write(`\u2192 [#${node.attrs.id}]`)
+        },
+        parse: {
+          updateDOM(element) {
+            // Replace occurrences of → [#123] in the HTML with anchor elements
+            element.innerHTML = element.innerHTML.replace(/\u2192\s\[#(\d{3})\]/g, (_, id) => {
+              return `<a data-arrow-id="${id}" href="#${id}">\u2192 #${id}</a>`
+            })
+          },
+        },
+      },
+    }
+  },
+})
+
+export default ArrowLink
+

--- a/src/CustomLink.ts
+++ b/src/CustomLink.ts
@@ -1,0 +1,10 @@
+import Link from '@tiptap/extension-link'
+
+// Link extension that ignores anchors used by ArrowLink
+const CustomLink = Link.extend({
+  parseHTML() {
+    return [{ tag: 'a[href]:not([data-arrow-id])' }]
+  },
+})
+
+export default CustomLink

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -3,35 +3,29 @@ import { Plus } from 'lucide-react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
-import Link from '@tiptap/extension-link'
 import { Markdown } from 'tiptap-markdown'
+import CustomLink from './CustomLink.ts'
+import ArrowLink from './ArrowLink.ts'
 import useLinearParser from './useLinearParser.ts'
-
-function preprocess(md = '') {
-  return md.replace(/\[#(\d{3})]/g, '[#$1](#$1)')
-}
-
-function postprocess(md = '') {
-  return md.replace(/\[#(\d{3})\]\(#\1\)/g, '[#$1]')
-}
 
 export default function LinearView({ text, setText, setNodes, nextId, onClose }) {
   const editor = useEditor({
     extensions: [
       StarterKit,
       Underline,
-      Link.configure({ openOnClick: false }),
+      CustomLink.configure({ openOnClick: false }),
+      ArrowLink,
       Markdown.configure({ html: false }),
     ],
-    content: preprocess(text || ''),
+    content: text || '',
     onUpdate({ editor }) {
-      setText(postprocess(editor.storage.markdown.getMarkdown()))
+      setText(editor.storage.markdown.getMarkdown())
     },
   })
 
   useEffect(() => {
-    if (editor && text !== postprocess(editor.storage.markdown.getMarkdown())) {
-      editor.commands.setContent(preprocess(text || ''))
+    if (editor && text !== editor.storage.markdown.getMarkdown()) {
+      editor.commands.setContent(text || '')
     }
   }, [text, editor])
 

--- a/src/__tests__/ArrowLink.test.ts
+++ b/src/__tests__/ArrowLink.test.ts
@@ -1,0 +1,22 @@
+import { Editor } from '@tiptap/core'
+import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
+import { Markdown } from 'tiptap-markdown'
+import CustomLink from '../CustomLink.ts'
+import ArrowLink from '../ArrowLink.ts'
+
+describe('ArrowLink markdown conversion', () => {
+  test('parses and serializes arrow links and bold text', () => {
+    const editor = new Editor({
+      extensions: [StarterKit, Underline, CustomLink, ArrowLink, Markdown],
+      content: '**bold** \u2192 [#123]',
+    })
+
+    const markdown = editor.storage.markdown.getMarkdown()
+    expect(markdown).toBe('**bold** \u2192 [#123]')
+
+    const html = editor.getHTML()
+    expect(html).toContain('data-arrow-id="123"')
+    expect(html).toContain('\u2192 #123')
+  })
+})


### PR DESCRIPTION
## Summary
- parse `→ [#id]` into clickable link via new ArrowLink tiptap node
- avoid collision with normal links through CustomLink extension
- ensure markdown import/export keeps formatting and arrow references

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce74fd70832fa14bc6b17d2599dd