### PR TITLE
Use HTML conversion for linear editor

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,7 +29,8 @@ import './App.css'
 import NodeCard from './NodeCard.jsx'
 import NodeEditorContext from './NodeEditorContext.ts'
 import Playthrough from './Playthrough.jsx'
-import LinearView from './LinearView.jsx'
+import LinearTextEditor from './LinearTextEditor.tsx'
+import { convertNodesToHtml } from './utils/linearConversion.ts'
 import AiSettingsModal from './AiSettingsModal.jsx'
 // import AiSuggestionsPanel from './AiSuggestionsPanel.jsx'
 // import { getSuggestions, proofreadText } from './useAi.js'
@@ -785,12 +786,10 @@ export default function App() {
   }, [nodes, edges, pushUndoState])
 
   const openLinearView = () => {
-    const md = nodes
-      .slice()
-      .sort((a, b) => Number(a.id) - Number(b.id))
-      .map(n => `## #${n.id} ${n.data.title}\n${n.data.text}`)
-      .join('\n')
-    setLinearText(md)
+    const html = convertNodesToHtml(
+      nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
+    )
+    setLinearText(html)
     setShowModal(true)
   }
 
@@ -1155,11 +1154,10 @@ export default function App() {
         )}
       </main>
       {showModal && (
-        <LinearView
-          text={linearText}
-          setText={setLinearText}
+        <LinearTextEditor
+          content={linearText}
+          nodes={nodes}
           setNodes={setNodes}
-          nextId={nextId}
           onClose={() => setShowModal(false)}
         />
       )}

--- a/src/LinearTextEditor.tsx
+++ b/src/LinearTextEditor.tsx
@@ -1,37 +1,29 @@
 import { useCallback } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
-import { parseLinearText } from './useLinearParser.ts'
-
-interface NodeData {
-  id: string
-  data: {
-    title?: string
-    text?: string
-  }
-}
+import type { Node } from 'reactflow'
+import { parseHtmlToNodes } from './utils/linearConversion.ts'
 
 interface Props {
-  nodes: NodeData[]
-  onSave: (nodes: ReturnType<typeof parseLinearText>) => void
+  content: string
+  nodes: Node[]
+  setNodes: (nodes: Node[]) => void
   onClose: () => void
 }
 
-export default function LinearTextEditor({ nodes = [], onSave, onClose }: Props) {
-  const initialContent = nodes
-    .map(n => `#${n.id} ${n.data?.title ?? ''}\n${n.data?.text ?? ''}`)
-    .join('\n\n')
-
+export default function LinearTextEditor({ content, nodes = [], setNodes, onClose }: Props) {
   const editor = useEditor({
     extensions: [StarterKit],
-    content: initialContent,
+    content,
   })
 
   const handleSave = useCallback(() => {
     if (!editor) return
-    const parsed = parseLinearText(editor.getText())
-    onSave(parsed)
-  }, [editor, onSave])
+    const html = editor.getHTML()
+    const parsed = parseHtmlToNodes(html, nodes)
+    setNodes(parsed)
+    onClose()
+  }, [editor, nodes, setNodes, onClose])
 
   if (!editor) return null
 


### PR DESCRIPTION
## Summary
- Convert nodes to HTML when opening the linear editor
- Parse HTML back to nodes on save and close the editor

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8d444805c832f944f147e5c898607