### PR TITLE
Improve Linear View editing and save behavior

### DIFF
--- a/src/LinearTextEditor.tsx
+++ b/src/LinearTextEditor.tsx
@@ -1,6 +1,8 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect } from 'react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
+import { Plus } from 'lucide-react'
 import type { Node } from 'reactflow'
 import { parseHtmlToNodes } from './utils/linearConversion.ts'
 
@@ -13,9 +15,17 @@ interface Props {
 
 export default function LinearTextEditor({ content, nodes = [], setNodes, onClose }: Props) {
   const editor = useEditor({
-    extensions: [StarterKit],
+    extensions: [StarterKit, Underline],
     content,
   })
+
+  const nextId = nodes.reduce((max, n) => Math.max(max, Number(n.id)), 0) + 1
+
+  const insertNextNodeNumber = () => {
+    if (!editor) return
+    const nodeId = `#${String(nextId).padStart(3, '0')}`
+    editor.chain().focus().insertContent(nodeId).run()
+  }
 
   const handleSave = useCallback(() => {
     if (!editor) return
@@ -24,6 +34,17 @@ export default function LinearTextEditor({ content, nodes = [], setNodes, onClos
     setNodes(parsed)
     onClose()
   }, [editor, nodes, setNodes, onClose])
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
+        e.preventDefault()
+        handleSave()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [handleSave])
 
   if (!editor) return null
 
@@ -35,6 +56,49 @@ export default function LinearTextEditor({ content, nodes = [], setNodes, onClos
         </button>
         <button className="btn ghost" type="button" onClick={onClose}>
           Close
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={() => editor.chain().focus().toggleBold().run()}
+        >
+          B
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+        >
+          I
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={() => editor.chain().focus().toggleUnderline().run()}
+        >
+          U
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
+        >
+          H1
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        >
+          H2
+        </button>
+        <button
+          className="btn ghost"
+          type="button"
+          onClick={insertNextNodeNumber}
+          aria-label="Next node number"
+        >
+          <Plus aria-hidden="true" />
         </button>
       </div>
       <EditorContent editor={editor} />

--- a/src/__tests__/LinearConversion.test.ts
+++ b/src/__tests__/LinearConversion.test.ts
@@ -29,4 +29,16 @@ describe('parseHtmlToNodes', () => {
     expect(nodes[1].width).toBe(DEFAULT_NODE_WIDTH)
     expect(nodes[1].position).toEqual({ x: 0, y: DEFAULT_NODE_HEIGHT })
   })
+
+  test('parses headings without data-node-id attribute', () => {
+    const html = `<h2>#001 Alpha</h2><p>A</p><h2>#002 Beta</h2><p>B</p>`
+    const nodes = parseHtmlToNodes(html)
+    expect(nodes).toHaveLength(2)
+    expect(nodes[0].id).toBe('001')
+    expect(nodes[0].data.title).toBe('Alpha')
+    expect(nodes[0].data.text).toBe('A')
+    expect(nodes[1].id).toBe('002')
+    expect(nodes[1].data.title).toBe('Beta')
+    expect(nodes[1].data.text).toBe('B')
+  })
 })

--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -28,15 +28,17 @@ export function convertNodesToHtml(nodes: Node[]): string {
 export function parseHtmlToNodes(html: string, prevNodes: Node[] = []): Node[] {
   const parser = new DOMParser()
   const doc = parser.parseFromString(html, 'text/html')
-  const headers = Array.from(doc.querySelectorAll('h2[data-node-id]'))
+  const headers = Array.from(doc.querySelectorAll('h2'))
   const prevMap = new Map(prevNodes.map(n => [n.id, n]))
 
   return headers.map((h2, index) => {
-    const id = h2.getAttribute('data-node-id') || ''
-    const title = (h2.textContent || '').replace(/^#\d+\s*/, '').trim()
+    const textContent = h2.textContent || ''
+    const idMatch = textContent.match(/^#(\d{3})/)
+    const id = h2.getAttribute('data-node-id') || (idMatch ? idMatch[1] : String(index + 1).padStart(3, '0'))
+    const title = textContent.replace(/^#\d+\s*/, '').trim()
     const paragraphs: string[] = []
     let el: Element | null = h2.nextElementSibling
-    while (el && !(el.tagName.toLowerCase() === 'h2' && el.hasAttribute('data-node-id'))) {
+    while (el && el.tagName.toLowerCase() !== 'h2') {
       if (el.tagName.toLowerCase() === 'p') {
         paragraphs.push(el.textContent || '')
       }


### PR DESCRIPTION
## Summary
- Restore formatting toolbar and add keyboard shortcut in linear text editor
- Preserve nodes when saving by parsing headers without data attributes
- Add tests for parsing headers without `data-node-id`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8df53e45c832f84798bafb95ab861