### PR TITLE
Handle Windows line endings in linear parser

### DIFF
--- a/src/__tests__/LinearParser.test.ts
+++ b/src/__tests__/LinearParser.test.ts
@@ -14,4 +14,13 @@ describe('parseLinearText', () => {
     expect(parsed).toHaveLength(1)
     expect(parsed[0].id).toBe('002')
   })
+
+  test('handles Windows line endings and special characters', () => {
+    const raw = '#001 First\r\nLine with -> [] and #010 reference\r\n\r\n#002 Second\r\nMore text'
+    const parsed = parseLinearText(raw)
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0].text).toContain('-> []')
+    expect(parsed[1].id).toBe('002')
+    expect(parsed[1].text).toBe('More text')
+  })
 })

--- a/src/useLinearParser.ts
+++ b/src/useLinearParser.ts
@@ -8,7 +8,8 @@ export interface ParsedNode {
 }
 
 export function parseLinearText(raw: string): ParsedNode[] {
-  const blocks = raw.split(/\n(?=(?:##\s+)?#\d{3}\s)/)
+  const normalized = raw.replace(/\r\n?/g, '\n')
+  const blocks = normalized.split(/\n(?=(?:##\s+)?#\d{3}\s)/)
   const ids = new Set<string>()
   const parsed: ParsedNode[] = []
   for (const block of blocks) {


### PR DESCRIPTION
## Summary
- Normalize CRLF line endings before parsing to prevent node removal
- Test parser with Windows line endings and special characters

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8e5e9ea94832fa196e6644951d881