### PR TITLE
Keep top menu visible above node graph

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,11 +17,15 @@ body {
 }
 
 header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
   display: flex;
   flex-wrap: wrap;
   gap: var(--gap);
   padding: var(--gap);
   border-bottom: 1px solid var(--panel);
+  background: var(--bg);
 }
 
 .btn {


### PR DESCRIPTION
## Summary
- Make top toolbar sticky with top offset and high z-index so it stays above the node graph

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb76e434832fa3ff7f9939e98dcb