### PR TITLE
Enable Linear View interface and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -29,8 +29,8 @@ import './App.css'
 import NodeCard from './NodeCard.jsx'
 import NodeEditorContext from './NodeEditorContext.ts'
 import Playthrough from './Playthrough.jsx'
-import LinearTextEditor from './LinearTextEditor.tsx'
-import { convertNodesToHtml } from './utils/linearConversion.ts'
+import LinearView from './LinearView.jsx'
+import { convertNodesToLinearText } from './utils/linearConversion.ts'
 import AiSettingsModal from './AiSettingsModal.jsx'
 // import AiSuggestionsPanel from './AiSuggestionsPanel.jsx'
 // import { getSuggestions, proofreadText } from './useAi.js'
@@ -787,10 +787,10 @@ export default function App() {
   }, [nodes, edges, pushUndoState])
 
   const openLinearView = () => {
-    const html = convertNodesToHtml(
+    const linear = convertNodesToLinearText(
       nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
     )
-    setLinearText(html)
+    setLinearText(linear)
     setShowModal(true)
   }
 
@@ -1155,10 +1155,11 @@ export default function App() {
         )}
       </main>
       {showModal && (
-        <LinearTextEditor
-          content={linearText}
-          nodes={nodes}
+        <LinearView
+          text={linearText}
+          setText={setLinearText}
           setNodes={setNodes}
+          nextId={nextId}
           onClose={() => setShowModal(false)}
         />
       )}

--- a/src/__tests__/LinearConversion.test.ts
+++ b/src/__tests__/LinearConversion.test.ts
@@ -1,4 +1,4 @@
-import { parseHtmlToNodes } from '../utils/linearConversion.ts'
+import { parseHtmlToNodes, convertNodesToLinearText } from '../utils/linearConversion.ts'
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '../constants.js'
 import type { Node } from 'reactflow'
 
@@ -52,5 +52,17 @@ describe('parseHtmlToNodes', () => {
     expect(nodes[1].id).toBe('002')
     expect(nodes[1].data.title).toBe('Next')
     expect(nodes[1].data.text).toBe('Second line')
+  })
+
+  test('converts nodes to linear text', () => {
+    const nodes = [
+      {
+        id: '001',
+        data: { title: 'Start', text: 'First line\nSecond line' },
+      } as any,
+      { id: '002', data: { title: 'Next', text: '' } } as any,
+    ]
+    const md = convertNodesToLinearText(nodes)
+    expect(md).toBe('#001 Start\nFirst line\nSecond line\n\n#002 Next')
   })
 })

--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -25,6 +25,20 @@ export function convertNodesToHtml(nodes: Node[]): string {
     .join('')
 }
 
+export function convertNodesToLinearText(nodes: Node[]): string {
+  return nodes
+    .map(n => {
+      const header = `#${String(n.id).padStart(3, '0')} ${n.data?.title || ''}`
+      const body = (n.data?.text || '')
+        .split(/\n+/)
+        .map(p => p.trim())
+        .filter(p => p.length > 0)
+        .join('\n')
+      return body ? `${header}\n${body}` : header
+    })
+    .join('\n\n')
+}
+
 export function parseHtmlToNodes(html: string, prevNodes: Node[] = []): Node[] {
   const parser = new DOMParser()
   const doc = parser.parseFromString(html, 'text/html')


### PR DESCRIPTION
## Summary
- bump app version to 0.0.3
- expose redesigned Linear View component with markdown parsing
- add utility and tests to convert nodes to linear text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f3b26dc0832f80b2fb74368d8f08