### PR TITLE
chore: clarify outline labels in linear view

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -61,7 +61,8 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
         const m = h.textContent.match(/^#(\d{3})(.*)$/)
         if (m) {
           h.dataset.id = m[1]
-          items.push({ id: m[1], title: h.textContent.trim() })
+          // store the title without the numeric id so we can format it separately
+          items.push({ id: m[1], title: m[2].trim() })
         }
       })
       setOutline(items)
@@ -124,7 +125,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
                     className="block w-full text-left text-sm p-2 rounded-md text-gray-300 hover:bg-gray-700/50"
                     onClick={() => jumpTo(item.id)}
                   >
-                    {item.title}
+                    #{item.id} {item.title}
                   </button>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
- Improve Linear View outline titles by storing title without node number
- Show node id and title separately in outline for easier navigation

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8f5660f30832f9897b91a56bace59