### PR TITLE
fix: ensure linear view adds newline after headers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/__tests__/LinearConversion.test.ts
+++ b/src/__tests__/LinearConversion.test.ts
@@ -1,5 +1,6 @@
 import { parseHtmlToNodes, convertNodesToLinearText } from '../utils/linearConversion.ts'
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from '../constants.js'
+import { parseLinearText } from '../useLinearParser.ts'
 import type { Node } from 'reactflow'
 
 describe('parseHtmlToNodes', () => {
@@ -63,6 +64,14 @@ describe('parseHtmlToNodes', () => {
       { id: '002', data: { title: 'Next', text: '' } } as any,
     ]
     const md = convertNodesToLinearText(nodes)
-    expect(md).toBe('#001 Start\nFirst line\nSecond line\n\n#002 Next')
+    expect(md).toBe('#001 Start\n\nFirst line\nSecond line\n\n#002 Next')
+  })
+
+  test('parseLinearText handles blank line after header', () => {
+    const raw = '#001 Start\n\nFirst line\n\n#002 Next'
+    const parsed = parseLinearText(raw)
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]).toEqual({ id: '001', title: 'Start', text: 'First line' })
+    expect(parsed[1]).toEqual({ id: '002', title: 'Next', text: '' })
   })
 })

--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -34,7 +34,7 @@ export function convertNodesToLinearText(nodes: Node[]): string {
         .map(p => p.trim())
         .filter(p => p.length > 0)
         .join('\n')
-      return body ? `${header}\n${body}` : header
+      return body ? `${header}\n\n${body}` : header
     })
     .join('\n\n')
 }


### PR DESCRIPTION
## Summary
- insert blank line after node headers when exporting to linear text
- test linear text parsing with blank line separation
- bump version to 0.0.5

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f8a40abc832fade275418e91c5d7