### PR TITLE
Improve linear text handling in Linear View

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -24,6 +24,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
   })
 
   const [outline, setOutline] = useState([])
+  const [next, setNext] = useState(nextId)
 
   useEffect(() => {
     if (editor && text !== editor.storage.markdown.getMarkdown()) {
@@ -33,10 +34,27 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
 
   useLinearParser(text, setNodes)
 
+  useEffect(() => {
+    setNext(nextId)
+  }, [nextId])
+
   const insertNextNodeNumber = () => {
     if (!editor) return
-    const nodeId = `#${String(nextId).padStart(3, '0')}`
+    const nodeId = `#${String(next).padStart(3, '0')}`
     editor.chain().focus().insertContent(nodeId).run()
+    setNext(n => n + 1)
+  }
+
+  const exportMarkdown = () => {
+    if (!editor) return
+    const md = editor.storage.markdown.getMarkdown()
+    const blob = new Blob([md], { type: 'text/markdown' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'linear.md'
+    a.click()
+    URL.revokeObjectURL(url)
   }
 
   const setLink = useCallback(() => {
@@ -103,6 +121,13 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               aria-label="Next node number"
             >
               <Plus aria-hidden="true" />
+            </button>
+            <button
+              className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-md"
+              type="button"
+              onClick={exportMarkdown}
+            >
+              Exportera
             </button>
             <button
               className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 rounded-md font-semibold"

--- a/src/__tests__/LinearConversion.test.ts
+++ b/src/__tests__/LinearConversion.test.ts
@@ -67,6 +67,21 @@ describe('parseHtmlToNodes', () => {
     expect(md).toBe('#001 Start\n\nFirst line\nSecond line\n\n#002 Next')
   })
 
+  test('preserves blank lines in node text', () => {
+    const nodes = [
+      { id: '001', data: { title: 'Start', text: 'Line1\n\nLine3' } } as any,
+    ]
+    const md = convertNodesToLinearText(nodes)
+    expect(md).toBe('#001 Start\n\nLine1\n\nLine3')
+  })
+
+  test('parseHtmlToNodes preserves blank paragraphs', () => {
+    const html = `<h2>#001 Start</h2><p>Line1</p><p></p><p>Line3</p>`
+    const nodes = parseHtmlToNodes(html)
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0].data.text).toBe('Line1\n\nLine3')
+  })
+
   test('parseLinearText handles blank line after header', () => {
     const raw = '#001 Start\n\nFirst line\n\n#002 Next'
     const parsed = parseLinearText(raw)

--- a/src/index.css
+++ b/src/index.css
@@ -522,6 +522,7 @@ main {
   padding: 1rem;
   outline: none;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
   overflow-y: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;
@@ -548,6 +549,8 @@ main {
 #linearEditor p {
   line-height: 1.7;
   margin-bottom: 1rem;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .node-link {

--- a/src/utils/linearConversion.ts
+++ b/src/utils/linearConversion.ts
@@ -16,8 +16,7 @@ export function convertNodesToHtml(nodes: Node[]): string {
       const title = escapeHtml(n.data?.title || '')
       const header = `<h2 data-node-id="${n.id}">#${n.id} ${title}</h2>`
       const paragraphs = (n.data?.text || '')
-        .split(/\n+/)
-        .filter(p => p.length > 0)
+        .split('\n')
         .map(p => `<p>${escapeHtml(p)}</p>`)
         .join('')
       return `${header}${paragraphs}`
@@ -29,11 +28,11 @@ export function convertNodesToLinearText(nodes: Node[]): string {
   return nodes
     .map(n => {
       const header = `#${String(n.id).padStart(3, '0')} ${n.data?.title || ''}`
-      const body = (n.data?.text || '')
-        .split(/\n+/)
-        .map(p => p.trim())
-        .filter(p => p.length > 0)
+      let body = (n.data?.text || '')
+        .split('\n')
+        .map(p => p.trimEnd())
         .join('\n')
+      body = body.replace(/\n+$/, '')
       return body ? `${header}\n\n${body}` : header
     })
     .join('\n\n')
@@ -63,11 +62,11 @@ export function parseHtmlToNodes(html: string, prevNodes: Node[] = []): Node[] {
       const txt = el.textContent || ''
       if (el.tagName.toLowerCase() === 'h2' || /^#\d{3}\s/.test(txt)) break
       if (el.tagName.toLowerCase() === 'p') {
-        if (txt.trim().length > 0) paragraphs.push(txt)
+        paragraphs.push(txt)
       }
       el = el.nextElementSibling
     }
-    const text = paragraphs.join('\n')
+    const text = paragraphs.join('\n').replace(/\n+$/, '')
     const prev = prevMap.get(id)
     if (prev) {
       return { ...prev, data: { ...prev.data, title, text } }


### PR DESCRIPTION
## Summary
- preserve blank lines and empty paragraphs when converting between nodes, HTML and markdown
- add export button and incremental node insertion in Linear View
- ensure linear editor text wraps correctly and add tests for blank line handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8faaca73c832fa41f8329fdcf57c1