### PR TITLE
feat: style node titles and outline

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -38,6 +38,27 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
     setNext(nextId)
   }, [nextId])
 
+  useEffect(() => {
+    if (!editor) return
+    const convertHeadings = () => {
+      const { doc, schema } = editor.state
+      let tr = editor.state.tr
+      let modified = false
+      doc.descendants((node, pos) => {
+        if (node.type.name === 'paragraph' && /^#\d{3}\s/.test(node.textContent)) {
+          tr = tr.setNodeMarkup(pos, schema.nodes.heading, { level: 2 })
+          modified = true
+        }
+      })
+      if (modified) {
+        editor.view.dispatch(tr)
+      }
+    }
+    convertHeadings()
+    editor.on('update', convertHeadings)
+    return () => editor.off('update', convertHeadings)
+  }, [editor])
+
   const insertNextNodeNumber = () => {
     if (!editor) return
     const nodeId = `#${String(next).padStart(3, '0')}`

--- a/src/index.css
+++ b/src/index.css
@@ -571,6 +571,21 @@ main {
   color: #0369a1;
 }
 
+.ProseMirror h2 {
+  font-family: 'Inter', sans-serif;
+  font-size: 1.5rem;
+  font-weight: 600;
+  border-bottom: 1px solid #e5e7eb;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+.ProseMirror p {
+  font-family: 'Lora', serif;
+  line-height: 1.7;
+  margin-bottom: 1rem;
+}
+
 .bubble-menu {
   display: flex;
   background-color: #1f2937;


### PR DESCRIPTION
## Summary
- convert node titles into level-2 headings for outline navigation
- polish editor typography with Inter and Lora fonts

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a905510890832fa4943ff5f1514f00