### PR TITLE
feat: polish linear view and linking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearTextEditor.tsx
+++ b/src/LinearTextEditor.tsx
@@ -15,7 +15,10 @@ interface Props {
 
 export default function LinearTextEditor({ content, nodes = [], setNodes, onClose }: Props) {
   const editor = useEditor({
-    extensions: [StarterKit, Underline],
+    extensions: [
+      StarterKit.configure({ bulletList: false, orderedList: false, listItem: false }),
+      Underline,
+    ],
     content,
   })
 


### PR DESCRIPTION
## Summary
- improve linear view outline with active section highlighting and independent scrolling
- add bubble menu link insertion for arrow links and disable list shortcuts
- bump version to 0.0.6

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95cfb5840832fa30cd4bde025aa8c