### PR TITLE
Improve Linear View UX

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.6",
+      "version": "0.0.7",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -145,8 +145,16 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
   if (!editor) return null
 
   const jumpTo = id => {
+    const container = mainRef.current
     const el = document.querySelector(`h2[data-id="${id}"]`)
-    el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    if (container && el) {
+      const top =
+        el.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        container.scrollTop
+      container.scrollTo({ top, behavior: 'smooth' })
+      setActiveId(id)
+    }
   }
 
   return (
@@ -203,7 +211,11 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
           </aside>
           <main ref={mainRef} className="flex-1 bg-gray-100 overflow-y-auto h-full p-4 sm:p-8 md:p-12 text-gray-900">
             <div className="max-w-3xl mx-auto relative">
-              <BubbleMenu editor={editor} className="bubble-menu">
+              <BubbleMenu
+                editor={editor}
+                className="bubble-menu"
+                tippyOptions={{ zIndex: 1000 }}
+              >
                 <button
                   onClick={() => editor.chain().focus().toggleBold().run()}
                   className={editor.isActive('bold') ? 'is-active' : ''}

--- a/src/index.css
+++ b/src/index.css
@@ -76,7 +76,7 @@ header {
   filter: brightness(1.1);
 }
 
-main {
+#root > main {
   flex: 1;
   display: grid;
   grid-template-columns: 1fr auto;


### PR DESCRIPTION
## Summary
- fix scroll region in Linear View
- ensure Tiptap BubbleMenu displays above editor content
- allow clicking outline items to scroll to the corresponding node
- bump version to 0.0.7

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9665d1234832fb441af54f1c6d66c