### PR TITLE
feat: refine linear view navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -95,20 +95,44 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
       const el = document.getElementById('linearEditor')
       if (!el) return
       const items = []
-      el.querySelectorAll('h2').forEach(h => {
-        const m = h.textContent.match(/^#(\d{3})(.*)$/)
-        if (m) {
-          h.dataset.id = m[1]
-          // store the title without the numeric id so we can format it separately
-          items.push({ id: m[1], title: m[2].trim() })
-        }
-      })
+        el.querySelectorAll('h2').forEach(h => {
+          const m = h.textContent.match(/^#(\d{3})(.*)$/)
+          if (m) {
+            h.dataset.id = m[1]
+            h.id = m[1]
+            // store the title without the numeric id so we can format it separately
+            items.push({ id: m[1], title: m[2].trim() })
+          }
+        })
       setOutline(items)
     }
     updateOutline()
     editor.on('update', updateOutline)
     return () => editor.off('update', updateOutline)
   }, [editor])
+
+  const jumpTo = useCallback(id => {
+    const el = document.querySelector(`h2[data-id="${id}"]`)
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      setActiveId(id)
+    }
+  }, [])
+
+  useEffect(() => {
+    const root = document.getElementById('linearEditor')
+    if (!root) return
+    const handle = e => {
+      const link = e.target.closest('a.node-link')
+      if (link) {
+        e.preventDefault()
+        const id = link.getAttribute('data-arrow-id')
+        if (id) jumpTo(id)
+      }
+    }
+    root.addEventListener('click', handle)
+    return () => root.removeEventListener('click', handle)
+  }, [jumpTo])
 
   useEffect(() => {
     const container = mainRef.current
@@ -145,14 +169,6 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
 
   if (!editor) return null
 
-  const jumpTo = id => {
-    const el = document.querySelector(`h2[data-id="${id}"]`)
-    if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
-      setActiveId(id)
-    }
-  }
-
   return (
     <div id="modal" role="dialog" aria-modal="true" className="show">
       <div className="w-full max-w-7xl mx-auto bg-gray-800 rounded-2xl shadow-2xl h-[90vh] flex flex-col">
@@ -184,7 +200,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
           </div>
         </header>
         <div className="flex flex-1 min-h-0">
-          <aside className="hidden md:block md:w-1/4 bg-gray-900/50 p-4 border-r border-gray-700 overflow-y-auto h-full min-h-0">
+          <aside className="hidden md:block md:w-1/4 bg-gray-900/50 p-4 border-r border-gray-700 overflow-y-auto h-full min-h-0 no-scrollbar">
             <h2 className="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-4">
               Outline
             </h2>
@@ -206,14 +222,14 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               ))}
             </ul>
           </aside>
-          <main
-            ref={mainRef}
-            className="flex-1 bg-gray-100 overflow-y-auto p-4 sm:p-8 md:p-12 text-gray-900 min-h-0"
-          >
-            <div className="max-w-3xl mx-auto relative">
-              <BubbleMenu
-                editor={editor}
-                className="bubble-menu"
+            <main
+              ref={mainRef}
+              className="flex-1 bg-gray-100 overflow-y-auto p-4 sm:p-8 md:p-12 text-gray-900 min-h-0 no-scrollbar"
+            >
+              <div className="max-w-3xl mx-auto relative">
+                <BubbleMenu
+                  editor={editor}
+                  className="bubble-menu"
                 tippyOptions={{ appendTo: () => document.body, zIndex: 10000 }}
               >
                 <button

--- a/src/index.css
+++ b/src/index.css
@@ -531,6 +531,15 @@ header {
   display: none;
 }
 
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+
 .linear-id {
   font: 11px/1 monospace;
   color: #777;


### PR DESCRIPTION
## Summary
- hide scrollbars in Linear View sidebar and content
- allow arrow links to jump to headings
- bump version to 0.0.10

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a96d3193c4832fbd23d36ed0371077