### PR TITLE
fix bubble menu and heading links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -123,11 +123,14 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
     const root = document.getElementById('linearEditor')
     if (!root) return
     const handle = e => {
-      const link = e.target.closest('a.node-link')
-      if (link) {
+      const anchor = e.target.closest('a')
+      if (!anchor) return
+      const href = anchor.getAttribute('href') || ''
+      if (!href.startsWith('#')) return
+      const id = href.slice(1)
+      if (/^\d{3}$/.test(id)) {
         e.preventDefault()
-        const id = link.getAttribute('data-arrow-id')
-        if (id) jumpTo(id)
+        jumpTo(id)
       }
     }
     root.addEventListener('click', handle)
@@ -227,10 +230,14 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               className="flex-1 bg-gray-100 overflow-y-auto p-4 sm:p-8 md:p-12 text-gray-900 min-h-0 no-scrollbar"
             >
               <div className="max-w-3xl mx-auto relative">
-                <BubbleMenu
-                  editor={editor}
-                  className="bubble-menu"
+              <BubbleMenu
+                editor={editor}
+                className="bubble-menu"
                 tippyOptions={{ appendTo: () => document.body, zIndex: 10000 }}
+                shouldShow={({ state }) => {
+                  const { from, to } = state.selection
+                  return from !== to
+                }}
               >
                 <button
                   onClick={() => editor.chain().focus().toggleBold().run()}


### PR DESCRIPTION
## Summary
- ensure internal heading links navigate within Linear View
- display bubble menu only when text is selected
- bump version to 0.0.11

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a9721a2a4c832fac8fe2750c8463d2