### PR TITLE
Use selection empty for BubbleMenu

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -236,8 +236,8 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
                 className="bubble-menu"
                 tippyOptions={{ appendTo: () => document.body, zIndex: 10000 }}
                 shouldShow={({ state }) => {
-                  const { from, to } = state.selection
-                  return from !== to
+                  console.log(state.selection)
+                  return !state.selection.empty
                 }}
               >
                 <button


### PR DESCRIPTION
## Summary
- use `state.selection.empty` to show bubble menu
- log selection for debugging

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a99c938910832f88d2f45d32fe02d8