### PR TITLE
Use main container for outline navigation scrolling

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -112,13 +112,14 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
   }, [editor])
 
   const jumpTo = useCallback(id => {
-    console.log('jumpTo', id)
-    const el = document.querySelector(`h2[data-id="${id}"]`)
+    const container = mainRef.current
+    if (!container) return
+    const el = container.querySelector(`h2[data-id="${id}"]`)
     if (el) {
-      el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+      container.scrollTo({ top: el.offsetTop - 20, behavior: 'smooth' })
       setActiveId(id)
     }
-  }, [])
+  }, [mainRef])
 
   useEffect(() => {
     const root = document.getElementById('linearEditor')


### PR DESCRIPTION
## Summary
- Navigate from outline entries by scrolling the main editor container to the target heading

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aae5d5c934832f927c7a4bf502ab7b