### PR TITLE
Add console logs for scroll debugging

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -113,9 +113,13 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
 
   const jumpTo = useCallback(id => {
     const container = mainRef.current
-    if (!container) return
-    const el = container.querySelector(`h2[data-id="${id}"]`)
-    if (el) {
+    const el = container?.querySelector(`h2[data-id="${id}"]`)
+
+    console.log('Försöker scrolla container:', container)
+    console.log('Målelement:', el)
+    console.log('Scroll-position (offsetTop):', el?.offsetTop)
+
+    if (container && el) {
       container.scrollTo({ top: el.offsetTop - 20, behavior: 'smooth' })
       setActiveId(id)
     }


### PR DESCRIPTION
## Summary
- log scroll container, target element, and offset in `jumpTo` to debug smooth scrolling issues

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaf9aeabe8832f8b96906302e3ac32