### PR TITLE
Fix scroll container and version positioning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.11",
+  "version": "0.0.12",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1212,7 +1212,7 @@ export default function App() {
         style={{
           position: 'fixed',
           bottom: 4,
-          right: 8,
+          right: 16,
           fontSize: '12px',
           opacity: 0.6,
         }}

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -178,9 +178,12 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
 
   if (!editor) return null
 
-  return (
-    <div id="modal" role="dialog" aria-modal="true" className="show">
-      <div className="w-full max-w-7xl mx-auto bg-gray-800 rounded-2xl shadow-2xl h-[90vh] flex flex-col">
+    return (
+      <div id="modal" role="dialog" aria-modal="true" className="show">
+        <div
+          ref={mainRef}
+          className="w-full max-w-7xl mx-auto bg-gray-800 rounded-2xl shadow-2xl h-[90vh] flex flex-col overflow-y-auto no-scrollbar"
+        >
         <header className="bg-gray-900 text-white p-3 flex items-center justify-between border-b border-gray-700">
           <h1 className="text-lg font-bold">Linear View</h1>
           <div className="flex items-center gap-3">
@@ -231,11 +234,8 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               ))}
             </ul>
           </aside>
-            <main
-              ref={mainRef}
-              className="flex-1 bg-gray-100 overflow-y-auto p-4 sm:p-8 md:p-12 text-gray-900 min-h-0 no-scrollbar"
-            >
-              <div className="max-w-3xl mx-auto relative">
+          <main className="flex-1 bg-gray-100 p-4 sm:p-8 md:p-12 text-gray-900 min-h-0">
+            <div className="max-w-3xl mx-auto relative">
               <BubbleMenu
                 editor={editor}
                 className="bubble-menu"


### PR DESCRIPTION
## Summary
- move scroll container to outer LinearView wrapper and remove inner overflow
- shift version badge left and bump to 0.0.12

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1cdf9704832fa38f53310b756c21