### PR TITLE
Fix offset scroll in LinearView

### DIFF
--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -181,8 +181,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
     return (
       <div id="modal" role="dialog" aria-modal="true" className="show">
         <div
-          ref={mainRef}
-          className="w-full max-w-7xl mx-auto bg-gray-800 rounded-2xl shadow-2xl h-[90vh] flex flex-col overflow-y-auto no-scrollbar"
+          className="w-full max-w-7xl mx-auto bg-gray-800 rounded-2xl shadow-2xl h-[90vh] flex flex-col"
         >
         <header className="bg-gray-900 text-white p-3 flex items-center justify-between border-b border-gray-700">
           <h1 className="text-lg font-bold">Linear View</h1>
@@ -234,7 +233,10 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               ))}
             </ul>
           </aside>
-          <main className="flex-1 bg-gray-100 p-4 sm:p-8 md:p-12 text-gray-900 min-h-0">
+          <main
+            ref={mainRef}
+            className="flex-1 bg-gray-100 p-4 sm:p-8 md:p-12 text-gray-900 min-h-0 overflow-y-auto no-scrollbar main-editor-container"
+          >
             <div className="max-w-3xl mx-auto relative">
               <BubbleMenu
                 editor={editor}

--- a/src/index.css
+++ b/src/index.css
@@ -540,6 +540,10 @@ header {
   display: none;
 }
 
+.main-editor-container {
+  position: relative;
+}
+
 .linear-id {
   font: 11px/1 monospace;
   color: #777;


### PR DESCRIPTION
## Summary
- make main editor container positioned relative so offsetTop is scoped to it
- move scroll ref to `<main>` and apply new class for consistent scrolling

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab3d61fd2c832f875fe953ede7f069