### PR TITLE
Fix LinearView scroll container and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.12",
+  "version": "0.0.13",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -234,9 +234,12 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
             </ul>
           </aside>
           <main
-            ref={mainRef}
-            className="flex-1 bg-gray-100 p-4 sm:p-8 md:p-12 text-gray-900 min-h-0 overflow-y-auto no-scrollbar main-editor-container"
+            className="flex-1 relative bg-gray-100 text-gray-900 min-h-0 overflow-hidden"
           >
+            <div
+              ref={mainRef}
+              className="absolute inset-0 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
+            >
             <div className="max-w-3xl mx-auto relative">
               <BubbleMenu
                 editor={editor}
@@ -267,6 +270,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
                 </button>
               </BubbleMenu>
               <EditorContent id="linearEditor" editor={editor} />
+            </div>
             </div>
           </main>
         </div>


### PR DESCRIPTION
## Summary
- wrap LinearView editor in dedicated scroll container to resolve flexbox scrolling bug
- bump version to 0.0.13

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab42c05a70832fa1ce3ce2dab8b608