### PR TITLE
fix: use flex layout for linear view scrolling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -234,11 +234,11 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
             </ul>
           </aside>
           <main
-            className="flex-1 relative bg-gray-100 text-gray-900 min-h-0 overflow-hidden"
+            className="flex-1 flex flex-col bg-gray-100 text-gray-900 min-h-0 overflow-hidden"
           >
             <div
               ref={mainRef}
-              className="absolute inset-0 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
+              className="flex-1 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
             >
             <div className="max-w-3xl mx-auto relative">
               <BubbleMenu


### PR DESCRIPTION
## Summary
- replace absolutely positioned editor container with nested flex layout for reliable scrolling
- bump version to 0.0.14

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab49d947d0832fb839b3caac5efa32