### PR TITLE
Use Tiptap scrollIntoView for heading navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.13",
+      "version": "0.0.15",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -112,18 +112,31 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
   }, [editor])
 
   const jumpTo = useCallback(id => {
-    const container = mainRef.current
-    const el = container?.querySelector(`h2[data-id="${id}"]`)
+    if (!editor) return
 
-    console.log('Försöker scrolla container:', container)
-    console.log('Målelement:', el)
-    console.log('Scroll-position (offsetTop):', el?.offsetTop)
+    let targetPos = null
+    const targetIdString = `#${id}`
 
-    if (container && el) {
-      container.scrollTo({ top: el.offsetTop - 20, behavior: 'smooth' })
+    editor.state.doc.descendants((node, pos) => {
+      if (
+        node.type.name === 'heading' &&
+        node.textContent.startsWith(targetIdString)
+      ) {
+        targetPos = pos
+        return false
+      }
+    })
+
+    if (targetPos !== null) {
+      editor
+        .chain()
+        .focus()
+        .setTextSelection(targetPos)
+        .scrollIntoView()
+        .run()
       setActiveId(id)
     }
-  }, [mainRef])
+  }, [editor])
 
   useEffect(() => {
     const root = document.getElementById('linearEditor')


### PR DESCRIPTION
## Summary
- Replace manual DOM scrolling with Tiptap's command chain to locate headings, move cursor, and scroll into view
- Bump package version to 0.0.15

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab4bcacbd8832fa2020dc2eb7f1791