### PR TITLE
feat: add Tiptap bubble menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.15",
+      "version": "0.0.16",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",
+        "@tiptap/extension-bubble-menu": "^2.13.0",
         "@tiptap/extension-link": "^2.13.0",
         "@tiptap/extension-underline": "^2.13.0",
         "@tiptap/react": "^2.13.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.15",
+  "version": "0.0.16",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -13,6 +13,7 @@
   "dependencies": {
     "@headlessui/react": "^2.2.4",
     "@heroicons/react": "^2.2.0",
+    "@tiptap/extension-bubble-menu": "^2.13.0",
     "@tiptap/extension-link": "^2.13.0",
     "@tiptap/extension-underline": "^2.13.0",
     "@tiptap/react": "^2.13.0",

--- a/src/EditorBubbleMenu.jsx
+++ b/src/EditorBubbleMenu.jsx
@@ -1,0 +1,44 @@
+import { BubbleMenu } from '@tiptap/react'
+
+const EditorBubbleMenu = ({ editor }) => {
+  if (!editor) {
+    return null
+  }
+
+  const insertArrowLink = () => {
+    const input = window.prompt('Node ID')
+    if (!input) return
+    const id = String(input).padStart(3, '0')
+    editor.chain().focus().insertContent({ type: 'arrowLink', attrs: { id } }).run()
+  }
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      tippyOptions={{ duration: 100 }}
+      className="bubble-menu"
+      shouldShow={({ state }) => state.selection.from !== state.selection.to}
+    >
+      <button
+        onClick={() => editor.chain().focus().toggleBold().run()}
+        className={editor.isActive('bold') ? 'is-active' : ''}
+      >
+        <b>B</b>
+      </button>
+      <button
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+        className={editor.isActive('italic') ? 'is-active' : ''}
+      >
+        <i>I</i>
+      </button>
+      <button
+        onClick={insertArrowLink}
+        className={editor.isActive('arrowLink') ? 'is-active' : ''}
+      >
+        Link
+      </button>
+    </BubbleMenu>
+  )
+}
+
+export default EditorBubbleMenu

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Plus } from 'lucide-react'
-import { BubbleMenu, EditorContent, useEditor } from '@tiptap/react'
+import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
 import { Markdown } from 'tiptap-markdown'
 import CustomLink from './CustomLink.ts'
 import ArrowLink from './ArrowLink.ts'
+import BubbleMenuExtension from '@tiptap/extension-bubble-menu'
+import EditorBubbleMenu from './EditorBubbleMenu.jsx'
 import useLinearParser from './useLinearParser.ts'
 import 'tippy.js/dist/tippy.css'
 
@@ -17,6 +19,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
       CustomLink.configure({ openOnClick: false }),
       ArrowLink,
       Markdown.configure({ html: false }),
+      BubbleMenuExtension,
     ],
     content: text || '',
     onUpdate({ editor }) {
@@ -80,14 +83,6 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
     a.click()
     URL.revokeObjectURL(url)
   }
-
-  const insertArrowLink = useCallback(() => {
-    if (!editor) return
-    const input = window.prompt('Node ID')
-    if (!input) return
-    const id = String(input).padStart(3, '0')
-    editor.chain().focus().insertContent({ type: 'arrowLink', attrs: { id } }).run()
-  }, [editor])
 
   useEffect(() => {
     if (!editor) return
@@ -254,34 +249,7 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
               className="flex-1 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
             >
             <div className="max-w-3xl mx-auto relative">
-              <BubbleMenu
-                editor={editor}
-                className="bubble-menu"
-                tippyOptions={{ appendTo: () => document.body, zIndex: 10000 }}
-                shouldShow={({ state }) => {
-                  console.log(state.selection)
-                  return !state.selection.empty
-                }}
-              >
-                <button
-                  onClick={() => editor.chain().focus().toggleBold().run()}
-                  className={editor.isActive('bold') ? 'is-active' : ''}
-                >
-                  <b>B</b>
-                </button>
-                <button
-                  onClick={() => editor.chain().focus().toggleItalic().run()}
-                  className={editor.isActive('italic') ? 'is-active' : ''}
-                >
-                  <i>I</i>
-                </button>
-                <button
-                  onClick={insertArrowLink}
-                  className={editor.isActive('arrowLink') ? 'is-active' : ''}
-                >
-                  Link
-                </button>
-              </BubbleMenu>
+              {editor && <EditorBubbleMenu editor={editor} />}
               <EditorContent id="linearEditor" editor={editor} />
             </div>
             </div>


### PR DESCRIPTION
## Summary
- replace inlined floating menu with Tiptap BubbleMenu
- integrate dedicated `EditorBubbleMenu` component in LinearView
- bump version to 0.0.16

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab4d8229ec832f861406b661197abc