### PR TITLE
feat: add heading button to editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.16",
+      "version": "0.0.17",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/EditorBubbleMenu.jsx
+++ b/src/EditorBubbleMenu.jsx
@@ -20,6 +20,12 @@ const EditorBubbleMenu = ({ editor }) => {
       shouldShow={({ state }) => state.selection.from !== state.selection.to}
     >
       <button
+        onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        className={editor.isActive('heading', { level: 2 }) ? 'is-active' : ''}
+      >
+        Heading
+      </button>
+      <button
         onClick={() => editor.chain().focus().toggleBold().run()}
         className={editor.isActive('bold') ? 'is-active' : ''}
       >


### PR DESCRIPTION
## Summary
- add Heading option to bubble menu to toggle H2 formatting
- bump version to 0.0.17

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab5cf9089c832fbd349fe458721d97