### PR TITLE
fix: show help icon in header and bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.18",
+    "version": "0.0.19",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.18",
+  "version": "0.0.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -212,21 +212,6 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
           <h1 className="text-lg font-bold">Linear View</h1>
           <div className="flex items-center gap-3">
             <button
-              className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-md"
-              type="button"
-              onClick={insertNextNodeNumber}
-              aria-label="Next node number"
-            >
-              <Plus aria-hidden="true" />
-            </button>
-            <button
-              className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-md"
-              type="button"
-              onClick={exportMarkdown}
-            >
-              Exportera
-            </button>
-            <button
               className="p-2 text-gray-300 hover:text-white"
               type="button"
               onClick={() => setShowShortcuts(true)}
@@ -234,13 +219,30 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
             >
               <HelpCircle aria-hidden="true" />
             </button>
-            <button
-              className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 rounded-md font-semibold"
-              type="button"
-              onClick={onClose}
-            >
-              Stäng
-            </button>
+            <div className="flex items-center gap-3">
+              <button
+                className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-md"
+                type="button"
+                onClick={insertNextNodeNumber}
+                aria-label="Next node number"
+              >
+                <Plus aria-hidden="true" />
+              </button>
+              <button
+                className="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 rounded-md"
+                type="button"
+                onClick={exportMarkdown}
+              >
+                Exportera
+              </button>
+              <button
+                className="px-3 py-1.5 text-sm bg-blue-600 hover:bg-blue-500 rounded-md font-semibold"
+                type="button"
+                onClick={onClose}
+              >
+                Stäng
+              </button>
+            </div>
           </div>
         </header>
         <div className="flex flex-1 min-h-0">


### PR DESCRIPTION
## Summary
- group action buttons so HelpCircle icon displays in header
- bump version to 0.0.19

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab753bf1dc832fa615e6fe1afa0b0a