### PR TITLE
feat: add sliding linear view panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.21",
+      "version": "0.0.22",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,7 +100,7 @@ export default function App() {
   const [text, setText] = useState('')
   const [title, setTitle] = useState('')
   const [linearText, setLinearText] = useState('')
-  const [showModal, setShowModal] = useState(false)
+  const [isLinearViewOpen, setLinearViewOpen] = useState(false)
   const [projectName, setProjectName] = useState('')
   const [showPlay, setShowPlay] = useState(false)
   const [autoSave, setAutoSave] = useState(() => {
@@ -791,7 +791,7 @@ export default function App() {
       nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
     )
     setLinearText(linear)
-    setShowModal(true)
+    setLinearViewOpen(true)
   }
 
   const startPlaythrough = () => {
@@ -1144,25 +1144,29 @@ export default function App() {
             placeholder="Title"
             disabled={!currentId}
           />
-          <textarea
-            id="text"
-            ref={textRef}
-            value={text}
-            onChange={onTextChange}
-            disabled={!currentId}
-          />
-        </section>
-        )}
-      </main>
-      {showModal && (
-        <LinearView
-          text={linearText}
-          setText={setLinearText}
-          setNodes={setNodes}
-          nextId={nextId}
-          onClose={() => setShowModal(false)}
+        <textarea
+          id="text"
+          ref={textRef}
+          value={text}
+          onChange={onTextChange}
+          disabled={!currentId}
         />
+      </section>
       )}
+      {/* Overlay for linear view */}
+      <div
+        className={`fixed inset-0 bg-black/50 transition-opacity duration-300 z-[60] ${isLinearViewOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        onClick={() => setLinearViewOpen(false)}
+      />
+      <LinearView
+        isOpen={isLinearViewOpen}
+        text={linearText}
+        setText={setLinearText}
+        setNodes={setNodes}
+        nextId={nextId}
+        onClose={() => setLinearViewOpen(false)}
+      />
+    </main>
       {showPlay && (
         <Playthrough
           nodes={nodes}
@@ -1205,7 +1209,7 @@ export default function App() {
         // onShowAiSettings={() => setShowAiSettings(true)}
         onLinearView={openLinearView}
         onPlaythrough={startPlaythrough}
-        onAutoLayout={!showModal && !showPlay ? handleAutoLayout : undefined}
+        onAutoLayout={!isLinearViewOpen && !showPlay ? handleAutoLayout : undefined}
         onHelp={openHelp}
       />
       <div

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -24,7 +24,7 @@ const KeyboardShortcuts = Extension.create({
   },
 })
 
-export default function LinearView({ text, setText, setNodes, nextId, onClose }) {
+export default function LinearView({ isOpen, text, setText, setNodes, nextId, onClose }) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({ bulletList: false, orderedList: false, listItem: false }),
@@ -201,79 +201,78 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
   if (!editor) return null
 
   return (
-    <>
-      <div id="modal" role="dialog" aria-modal="true" className="show">
-        <div className="w-full max-w-7xl mx-auto linear-container rounded-2xl shadow-2xl h-[90vh] flex flex-col">
-          <header className="linear-header p-3 flex items-center justify-between border-b">
-            <h1 className="text-lg font-bold">Linear View</h1>
-            <div className="flex items-center gap-3">
-              <button
-                className="btn"
-                type="button"
-                onClick={insertNextNodeNumber}
-                aria-label="Next node number"
-              >
-                <Plus aria-hidden="true" />
-              </button>
-              <button className="btn" type="button" onClick={exportMarkdown}>
-                Exportera
-              </button>
-              <button className="btn primary" type="button" onClick={onClose}>
-                Stäng
-              </button>
-            </div>
-          </header>
-          <div className="flex flex-1 min-h-0">
-            <aside className="hidden md:flex md:flex-col md:w-1/4 linear-sidebar h-full min-h-0">
-              <div className="flex-1 overflow-y-auto p-4 no-scrollbar">
-                <h2 className="text-sm font-semibold text-dim uppercase tracking-wider mb-4">
-                  Outline
-                </h2>
-                <ul className="space-y-1">
-                  {outline.map(item => (
-                    <li key={item.id}>
-                      <button
-                        type="button"
-                        className={`outline-btn block w-full text-left text-sm p-2 rounded-md ${
-                          activeId === item.id ? 'active' : ''
-                        }`}
-                        onClick={() => jumpTo(item.id)}
-                      >
-                        #{item.id} {item.title}
-                      </button>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <footer className="p-4 border-t linear-footer">
-                <h3 className="text-xs font-semibold text-dim uppercase mb-2">Shortcuts</h3>
-                <div className="text-xs text-dim space-y-1">
-                  <p>
-                    <span className="font-mono shortcut-key">Cmd/Ctrl + B</span>: Bold
-                  </p>
-                  <p>
-                    <span className="font-mono shortcut-key">Cmd/Ctrl + I</span>: Italic
-                  </p>
-                  <p>
-                    <span className="font-mono shortcut-key">Cmd/Ctrl + Opt + 2</span>: Heading
-                  </p>
-                </div>
-              </footer>
-            </aside>
-            <main className="flex-1 flex flex-col linear-main min-h-0 overflow-hidden">
-              <div
-                ref={mainRef}
-                className="flex-1 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
-              >
-                <div className="max-w-3xl mx-auto relative">
-                  {editor && <EditorBubbleMenu editor={editor} />}
-                  <EditorContent id="linearEditor" editor={editor} />
-                </div>
-              </div>
-            </main>
-          </div>
+    <div
+      className="fixed top-0 right-0 h-full w-4/5 bg-gray-800 linear-container shadow-2xl transform transition-transform duration-300 ease-in-out z-[70] flex flex-col"
+      style={{ transform: isOpen ? 'translateX(0)' : 'translateX(100%)' }}
+    >
+      <header className="linear-header p-3 flex items-center justify-between border-b">
+        <h1 className="text-lg font-bold">Linear View</h1>
+        <div className="flex items-center gap-3">
+          <button
+            className="btn"
+            type="button"
+            onClick={insertNextNodeNumber}
+            aria-label="Next node number"
+          >
+            <Plus aria-hidden="true" />
+          </button>
+          <button className="btn" type="button" onClick={exportMarkdown}>
+            Exportera
+          </button>
+          <button className="btn primary" type="button" onClick={onClose}>
+            Stäng
+          </button>
         </div>
+      </header>
+      <div className="flex flex-1 min-h-0">
+        <aside className="hidden md:flex md:flex-col md:w-1/4 linear-sidebar h-full min-h-0">
+          <div className="flex-1 overflow-y-auto p-4 no-scrollbar">
+            <h2 className="text-sm font-semibold text-dim uppercase tracking-wider mb-4">
+              Outline
+            </h2>
+            <ul className="space-y-1">
+              {outline.map(item => (
+                <li key={item.id}>
+                  <button
+                    type="button"
+                    className={`outline-btn block w-full text-left text-sm p-2 rounded-md ${
+                      activeId === item.id ? 'active' : ''
+                    }`}
+                    onClick={() => jumpTo(item.id)}
+                  >
+                    #{item.id} {item.title}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <footer className="p-4 border-t linear-footer">
+            <h3 className="text-xs font-semibold text-dim uppercase mb-2">Shortcuts</h3>
+            <div className="text-xs text-dim space-y-1">
+              <p>
+                <span className="font-mono shortcut-key">Cmd/Ctrl + B</span>: Bold
+              </p>
+              <p>
+                <span className="font-mono shortcut-key">Cmd/Ctrl + I</span>: Italic
+              </p>
+              <p>
+                <span className="font-mono shortcut-key">Cmd/Ctrl + Opt + 2</span>: Heading
+              </p>
+            </div>
+          </footer>
+        </aside>
+        <main className="flex-1 flex flex-col linear-main min-h-0 overflow-hidden">
+          <div
+            ref={mainRef}
+            className="flex-1 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
+          >
+            <div className="max-w-3xl mx-auto relative">
+              {editor && <EditorBubbleMenu editor={editor} />}
+              <EditorContent id="linearEditor" editor={editor} />
+            </div>
+          </div>
+        </main>
       </div>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- change linear view into slide-in panel over node view with overlay
- manage linear view state in App
- bump version to 0.0.22

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac034a5e1c832fa19324d2d871fa4b