### PR TITLE
Refactor layout to embed Linear View panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,7 +100,7 @@ export default function App() {
   const [text, setText] = useState('')
   const [title, setTitle] = useState('')
   const [linearText, setLinearText] = useState('')
-  const [isLinearViewOpen, setLinearViewOpen] = useState(false)
+  const [isPanelExpanded, setPanelExpanded] = useState(false)
   const [projectName, setProjectName] = useState('')
   const [showPlay, setShowPlay] = useState(false)
   const [autoSave, setAutoSave] = useState(() => {
@@ -786,12 +786,14 @@ export default function App() {
     setEdges(layoutedEdges)
   }, [nodes, edges, pushUndoState])
 
-  const openLinearView = () => {
-    const linear = convertNodesToLinearText(
-      nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
-    )
-    setLinearText(linear)
-    setLinearViewOpen(true)
+  const togglePanel = () => {
+    if (!isPanelExpanded) {
+      const linear = convertNodesToLinearText(
+        nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
+      )
+      setLinearText(linear)
+    }
+    setPanelExpanded(p => !p)
   }
 
   const startPlaythrough = () => {
@@ -844,6 +846,12 @@ export default function App() {
 
   return (
     <>
+      <div
+        className={`grid h-screen ${
+          isPanelExpanded ? 'grid-cols-[1fr_2fr]' : 'grid-cols-[3fr_1fr]'
+        }`}
+      >
+        <div className="overflow-hidden">
       <header>
         <Button
           variant="primary"
@@ -1153,20 +1161,19 @@ export default function App() {
         />
       </section>
       )}
-      {/* Overlay for linear view */}
-      <div
-        className={`fixed inset-0 bg-black/50 transition-opacity duration-300 z-[60] ${isLinearViewOpen ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-        onClick={() => setLinearViewOpen(false)}
-      />
-      <LinearView
-        isOpen={isLinearViewOpen}
-        text={linearText}
-        setText={setLinearText}
-        setNodes={setNodes}
-        nextId={nextId}
-        onClose={() => setLinearViewOpen(false)}
-      />
     </main>
+        </div>
+        <div className="border-l border-gray-700">
+          <LinearView
+            isExpanded={isPanelExpanded}
+            text={linearText}
+            setText={setLinearText}
+            setNodes={setNodes}
+            nextId={nextId}
+            onToggle={togglePanel}
+          />
+        </div>
+      </div>
       {showPlay && (
         <Playthrough
           nodes={nodes}
@@ -1207,9 +1214,9 @@ export default function App() {
       <FloatingMenu
         onShowSettings={openSettings}
         // onShowAiSettings={() => setShowAiSettings(true)}
-        onLinearView={openLinearView}
+        onLinearView={togglePanel}
         onPlaythrough={startPlaythrough}
-        onAutoLayout={!isLinearViewOpen && !showPlay ? handleAutoLayout : undefined}
+        onAutoLayout={!isPanelExpanded && !showPlay ? handleAutoLayout : undefined}
         onHelp={openHelp}
       />
       <div

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight } from 'lucide-react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -24,7 +24,7 @@ const KeyboardShortcuts = Extension.create({
   },
 })
 
-export default function LinearView({ isOpen, text, setText, setNodes, nextId, onClose }) {
+export default function LinearView({ isExpanded, text, setText, setNodes, nextId, onToggle }) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({ bulletList: false, orderedList: false, listItem: false }),
@@ -191,20 +191,17 @@ export default function LinearView({ isOpen, text, setText, setNodes, nextId, on
     const handler = e => {
       if ((e.metaKey || e.ctrlKey) && e.key === 's') {
         e.preventDefault()
-        onClose()
+        onToggle()
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [onClose])
+  }, [onToggle])
 
   if (!editor) return null
 
   return (
-    <div
-      className="fixed top-0 right-0 h-full w-4/5 bg-gray-800 linear-container shadow-2xl transform transition-transform duration-300 ease-in-out z-[70] flex flex-col"
-      style={{ transform: isOpen ? 'translateX(0)' : 'translateX(100%)' }}
-    >
+    <div className="h-full flex flex-col linear-container">
       <header className="linear-header p-3 flex items-center justify-between border-b">
         <h1 className="text-lg font-bold">Linear View</h1>
         <div className="flex items-center gap-3">
@@ -219,8 +216,13 @@ export default function LinearView({ isOpen, text, setText, setNodes, nextId, on
           <button className="btn" type="button" onClick={exportMarkdown}>
             Exportera
           </button>
-          <button className="btn primary" type="button" onClick={onClose}>
-            Stäng
+          <button
+            className="btn primary"
+            type="button"
+            onClick={onToggle}
+            aria-label="Toggle panel"
+          >
+            {isExpanded ? <ChevronRight /> : <ChevronLeft />}
           </button>
         </div>
       </header>
@@ -235,7 +237,7 @@ export default function LinearView({ isOpen, text, setText, setNodes, nextId, on
                 <li key={item.id}>
                   <button
                     type="button"
-                    className={`outline-btn block w-full text-left text-sm p-2 rounded-md ${
+                    className={`outline-btn block w-full text-left text-sm p-2 rounded-md transition-colors ${
                       activeId === item.id ? 'active' : ''
                     }`}
                     onClick={() => jumpTo(item.id)}


### PR DESCRIPTION
## Summary
- Restructure App into responsive two-column grid with persistent LinearView panel
- Add expand/collapse toggle and restore Outline navigation styling
- Bump version to 0.0.23

## Testing
- `npm test`
- `npm run lint` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0a26e400832f8157d47e022b3355