### PR TITLE
fix: keep nodes when linear view is empty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-      "version": "0.0.23",
+    "version": "0.0.24",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/useLinearParser.ts
+++ b/src/useLinearParser.ts
@@ -30,6 +30,7 @@ export function parseLinearText(raw: string): ParsedNode[] {
 export default function useLinearParser(raw: string = '', setNodes: any): void {
   useEffect(() => {
     if (typeof setNodes !== 'function') return
+    if (!raw || !raw.trim()) return
     const parsed = parseLinearText(raw)
     setNodes((ns: any[]) => {
       const map = new Map(ns.map(n => [n.id, n]))


### PR DESCRIPTION
## Summary
- avoid clearing nodes if linear view text is empty
- bump version to 0.0.24

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac0f87b928832fab4d9cc6858a2856