### PR TITLE
feat: add expandable linear panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.21",
+    "version": "0.0.22",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.21",
+  "version": "0.0.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -100,7 +100,7 @@ export default function App() {
   const [text, setText] = useState('')
   const [title, setTitle] = useState('')
   const [linearText, setLinearText] = useState('')
-  const [showModal, setShowModal] = useState(false)
+  const [linearExpanded, setLinearExpanded] = useState(false)
   const [projectName, setProjectName] = useState('')
   const [showPlay, setShowPlay] = useState(false)
   const [autoSave, setAutoSave] = useState(() => {
@@ -140,6 +140,10 @@ export default function App() {
     document.documentElement.setAttribute('data-theme', theme)
     localStorage.setItem('vv-theme', theme)
   }, [theme])
+
+  useEffect(() => {
+    setLinearText(convertNodesToLinearText(nodes))
+  }, [nodes])
 
   const {
     projects,
@@ -786,14 +790,6 @@ export default function App() {
     setEdges(layoutedEdges)
   }, [nodes, edges, pushUndoState])
 
-  const openLinearView = () => {
-    const linear = convertNodesToLinearText(
-      nodes.slice().sort((a, b) => Number(a.id) - Number(b.id))
-    )
-    setLinearText(linear)
-    setShowModal(true)
-  }
-
   const startPlaythrough = () => {
     setShowPlay(true)
   }
@@ -999,170 +995,171 @@ export default function App() {
         </Button>
 
       </header>
-      <main style={{ position: 'relative' }}>
-        <div id="graph">
-          <NodeEditorContext.Provider value={{ updateNodeText, resizingRef }}>
-          <ReactFlow
-            style={{ width: '100%', height: '100%' }}
-            nodes={nodes}
-            edges={edges}
-            defaultEdgeOptions={defaultEdgeOptions}
-            onNodesChange={onNodesChange}
-            onEdgesChange={onEdgesChange}
-            onConnect={onConnect}
-            onNodeClick={onNodeClick}
-            onReconnect={onReconnect}
-            onReconnectStart={onReconnectStart}
-            onReconnectEnd={onReconnectEnd}
-            edgesUpdatable
-            onPaneClick={onPaneClick}
-            nodeTypes={nodeTypes}
-            snapToGrid
-            snapGrid={[16, 16]}
-            fitView
-          >
-          <Background color="#374151" variant="dots" gap={16} size={1} />
-          <MiniMap zoomable pannable />
-          <Controls />
-        </ReactFlow>
-        </NodeEditorContext.Provider>
-      </div>
-        <button
-          id="toggleEditor"
-          className="btn ghost"
-          type="button"
-          style={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', right: editorCollapsed ? 0 : '300px', zIndex: 1 }}
-          aria-label={editorCollapsed ? 'Expand editor' : 'Collapse editor'}
-          title={editorCollapsed ? 'Expand editor' : 'Collapse editor'}
-          onClick={() => setEditorCollapsed(c => !c)}
-        >
-          {editorCollapsed ? <ChevronLeft /> : <ChevronRight />}
-        </button>
-        {!editorCollapsed && (
-        <section id="editor">
-          <h2 id="nodeId">#{currentId || '000'} {title}</h2>
-        <div id="formatting-toolbar">
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={() => wrapSelected('**')}
-            title="Bold (Ctrl+B)"
-          >
-            B
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={() => wrapSelected('*')}
-            title="Italic (Ctrl+I)"
-          >
-            I
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={() => wrapSelected('__')}
-            title="Underline (Ctrl+U)"
-          >
-            U
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={() => applyHeading(1)}
-            title="Heading 1"
-          >
-            H1
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={() => applyHeading(2)}
-            title="Heading 2"
-          >
-            H2
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={insertNextNodeNumber}
-            aria-label="Next node number"
-            title="Insert next node number"
-          >
-            <Plus aria-hidden="true" />
-          </button>
-          {/*
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={fetchAiSuggestions}
-            aria-label="AI suggestions"
-          >
-            <Cloud aria-hidden="true" />
-          </button>
-          <button
-            className="btn ghost"
-            type="button"
-            onClick={fetchProofread}
-            aria-label="AI proofread"
-          >
-            <SpellCheck aria-hidden="true" />
-          </button>
-          */}
-          <div style={{ position: 'relative' }}>
-            <button
-              className="color-button"
-              type="button"
-              onClick={() => setShowColorPicker(c => !c)}
-              aria-label="Node color"
-              title="Node color"
-              style={{
-                background:
-                  nodes.find(n => n.id === currentId)?.data.color || '#1f2937',
-              }}
-            />
-            {showColorPicker && (
-              <div className="color-picker">
-                {COLOR_OPTIONS.map(col => (
-                  <div
-                    key={col}
-                    className="color-swatch"
-                    style={{ background: col }}
-                    onClick={() => changeNodeColor(col)}
-                  />
-                ))}
-              </div>
-            )}
+      <main className={`workspace ${linearExpanded ? 'expanded' : ''}`}>
+        <div id="graph-container">
+          <div id="graph">
+            <NodeEditorContext.Provider value={{ updateNodeText, resizingRef }}>
+              <ReactFlow
+                style={{ width: '100%', height: '100%' }}
+                nodes={nodes}
+                edges={edges}
+                defaultEdgeOptions={defaultEdgeOptions}
+                onNodesChange={onNodesChange}
+                onEdgesChange={onEdgesChange}
+                onConnect={onConnect}
+                onNodeClick={onNodeClick}
+                onReconnect={onReconnect}
+                onReconnectStart={onReconnectStart}
+                onReconnectEnd={onReconnectEnd}
+                edgesUpdatable
+                onPaneClick={onPaneClick}
+                nodeTypes={nodeTypes}
+                snapToGrid
+                snapGrid={[16, 16]}
+                fitView
+              >
+                <Background color="#374151" variant="dots" gap={16} size={1} />
+                <MiniMap zoomable pannable />
+                <Controls />
+              </ReactFlow>
+            </NodeEditorContext.Provider>
           </div>
-          {/* AI loading indicator removed */}
-          {/* Settings button moved to header */}
+          <button
+            id="toggleEditor"
+            className="btn ghost"
+            type="button"
+            style={{ position: 'absolute', top: '50%', transform: 'translateY(-50%)', right: editorCollapsed ? 0 : '300px', zIndex: 1 }}
+            aria-label={editorCollapsed ? 'Expand editor' : 'Collapse editor'}
+            title={editorCollapsed ? 'Expand editor' : 'Collapse editor'}
+            onClick={() => setEditorCollapsed(c => !c)}
+          >
+            {editorCollapsed ? <ChevronLeft /> : <ChevronRight />}
+          </button>
+          {!editorCollapsed && (
+            <section id="editor">
+              <h2 id="nodeId">#{currentId || '000'} {title}</h2>
+              <div id="formatting-toolbar">
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={() => wrapSelected('**')}
+                  title="Bold (Ctrl+B)"
+                >
+                  B
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={() => wrapSelected('*')}
+                  title="Italic (Ctrl+I)"
+                >
+                  I
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={() => wrapSelected('__')}
+                  title="Underline (Ctrl+U)"
+                >
+                  U
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={() => applyHeading(1)}
+                  title="Heading 1"
+                >
+                  H1
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={() => applyHeading(2)}
+                  title="Heading 2"
+                >
+                  H2
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={insertNextNodeNumber}
+                  aria-label="Next node number"
+                  title="Insert next node number"
+                >
+                  <Plus aria-hidden="true" />
+                </button>
+                {/*
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={fetchAiSuggestions}
+                  aria-label="AI suggestions"
+                >
+                  <Cloud aria-hidden="true" />
+                </button>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={fetchProofread}
+                  aria-label="AI proofread"
+                >
+                  <SpellCheck aria-hidden="true" />
+                </button>
+                */}
+                <div style={{ position: 'relative' }}>
+                  <button
+                    className="color-button"
+                    type="button"
+                    onClick={() => setShowColorPicker(c => !c)}
+                    aria-label="Node color"
+                    title="Node color"
+                    style={{
+                      background:
+                        nodes.find(n => n.id === currentId)?.data.color || '#1f2937',
+                    }}
+                  />
+                  {showColorPicker && (
+                    <div className="color-picker">
+                      {COLOR_OPTIONS.map(col => (
+                        <div
+                          key={col}
+                          className="color-swatch"
+                          style={{ background: col }}
+                          onClick={() => changeNodeColor(col)}
+                        />
+                      ))}
+                    </div>
+                  )}
+                </div>
+                {/* AI loading indicator removed */}
+                {/* Settings button moved to header */}
+              </div>
+              <input
+                id="title"
+                value={title}
+                onChange={onTitleChange}
+                placeholder="Title"
+                disabled={!currentId}
+              />
+              <textarea
+                id="text"
+                ref={textRef}
+                value={text}
+                onChange={onTextChange}
+                disabled={!currentId}
+              />
+            </section>
+          )}
         </div>
-          <input
-            id="title"
-            value={title}
-            onChange={onTitleChange}
-            placeholder="Title"
-            disabled={!currentId}
-          />
-          <textarea
-            id="text"
-            ref={textRef}
-            value={text}
-            onChange={onTextChange}
-            disabled={!currentId}
-          />
-        </section>
-        )}
-      </main>
-      {showModal && (
         <LinearView
           text={linearText}
           setText={setLinearText}
           setNodes={setNodes}
           nextId={nextId}
-          onClose={() => setShowModal(false)}
+          expanded={linearExpanded}
+          onToggleExpand={() => setLinearExpanded(e => !e)}
         />
-      )}
+      </main>
       {showPlay && (
         <Playthrough
           nodes={nodes}
@@ -1203,9 +1200,8 @@ export default function App() {
       <FloatingMenu
         onShowSettings={openSettings}
         // onShowAiSettings={() => setShowAiSettings(true)}
-        onLinearView={openLinearView}
         onPlaythrough={startPlaythrough}
-        onAutoLayout={!showModal && !showPlay ? handleAutoLayout : undefined}
+        onAutoLayout={!showPlay ? handleAutoLayout : undefined}
         onHelp={openHelp}
       />
       <div

--- a/src/FloatingMenu.jsx
+++ b/src/FloatingMenu.jsx
@@ -4,7 +4,6 @@ import {
   Menu,
   Settings,
   HelpCircle,
-  List,
   Play,
   LayoutGrid,
 } from 'lucide-react'
@@ -13,7 +12,6 @@ const sectionConfig = [
   {
     title: 'View',
     items: [
-      { label: 'Linear View', icon: List, action: 'onLinearView' },
       { label: 'Playthrough', icon: Play, action: 'onPlaythrough' },
     ],
   },
@@ -33,14 +31,12 @@ const sectionConfig = [
 export default function FloatingMenu({
   onShowSettings,
   // onShowAiSettings,
-  onLinearView,
   onPlaythrough,
   onAutoLayout,
   onHelp,
 }) {
   const propMap = {
     onShowSettings,
-    onLinearView,
     onPlaythrough,
     onAutoLayout,
     onHelp,

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Plus } from 'lucide-react'
+import { Plus, ChevronLeft, ChevronRight } from 'lucide-react'
 import { EditorContent, useEditor } from '@tiptap/react'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -24,7 +24,7 @@ const KeyboardShortcuts = Extension.create({
   },
 })
 
-export default function LinearView({ text, setText, setNodes, nextId, onClose }) {
+export default function LinearView({ text, setText, setNodes, nextId, expanded, onToggleExpand }) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({ bulletList: false, orderedList: false, listItem: false }),
@@ -187,42 +187,38 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
     return () => container.removeEventListener('scroll', handleScroll)
   }, [outline])
 
-  useEffect(() => {
-    const handler = e => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 's') {
-        e.preventDefault()
-        onClose()
-      }
-    }
-    window.addEventListener('keydown', handler)
-    return () => window.removeEventListener('keydown', handler)
-  }, [onClose])
 
   if (!editor) return null
 
   return (
-    <>
-      <div id="modal" role="dialog" aria-modal="true" className="show">
-        <div className="w-full max-w-7xl mx-auto linear-container rounded-2xl shadow-2xl h-[90vh] flex flex-col">
-          <header className="linear-header p-3 flex items-center justify-between border-b">
-            <h1 className="text-lg font-bold">Linear View</h1>
-            <div className="flex items-center gap-3">
-              <button
-                className="btn"
-                type="button"
-                onClick={insertNextNodeNumber}
-                aria-label="Next node number"
-              >
-                <Plus aria-hidden="true" />
-              </button>
-              <button className="btn" type="button" onClick={exportMarkdown}>
-                Exportera
-              </button>
-              <button className="btn primary" type="button" onClick={onClose}>
-                Stäng
-              </button>
-            </div>
-          </header>
+    <div id="linear-panel" className="linear-container flex flex-col h-full">
+      <header className="linear-header p-3 flex items-center justify-between border-b">
+        <div className="flex items-center gap-2">
+          <button
+            className="btn ghost"
+            type="button"
+            onClick={onToggleExpand}
+            title={expanded ? 'Collapse' : 'Expand'}
+            aria-label={expanded ? 'Collapse panel' : 'Expand panel'}
+          >
+            {expanded ? <ChevronRight /> : <ChevronLeft />}
+          </button>
+          <h1 className="text-lg font-bold">Linear View</h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            className="btn"
+            type="button"
+            onClick={insertNextNodeNumber}
+            aria-label="Next node number"
+          >
+            <Plus aria-hidden="true" />
+          </button>
+          <button className="btn" type="button" onClick={exportMarkdown}>
+            Exportera
+          </button>
+        </div>
+      </header>
           <div className="flex flex-1 min-h-0">
             <aside className="hidden md:flex md:flex-col md:w-1/4 linear-sidebar h-full min-h-0">
               <div className="flex-1 overflow-y-auto p-4 no-scrollbar">
@@ -273,7 +269,5 @@ export default function LinearView({ text, setText, setNodes, nextId, onClose })
             </main>
           </div>
         </div>
-      </div>
-    </>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -78,9 +78,33 @@ header {
 
 #root > main {
   flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+.workspace #graph-container {
+  position: relative;
   display: grid;
   grid-template-columns: 1fr auto;
+  width: 70%;
+  transition: width 0.3s;
+}
+
+.workspace #linear-panel {
+  width: 30%;
+  transition: width 0.3s;
+  border-left: 1px solid var(--panel);
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.workspace.expanded #graph-container {
+  width: 20%;
+}
+
+.workspace.expanded #linear-panel {
+  width: 80%;
 }
 
 #toggleEditor {


### PR DESCRIPTION
## Summary
- integrate Linear View as side panel with collapsible and expanded states
- adjust layout styles for two-column workspace
- bump version to 0.0.22

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac14c45f90832f92f83bb5da45c4e6