### PR TITLE
refactor: replace inspector with collapsible linear panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.22",
+    "version": "0.0.23",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.22",
+  "version": "0.0.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/index.css
+++ b/src/index.css
@@ -84,8 +84,7 @@ header {
 
 .workspace #graph-container {
   position: relative;
-  display: grid;
-  grid-template-columns: 1fr auto;
+  display: flex;
   width: 70%;
   transition: width 0.3s;
 }
@@ -107,59 +106,10 @@ header {
   width: 80%;
 }
 
-#toggleEditor {
-  position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 24px;
-  height: 40px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px solid var(--panel);
-  border-right: none;
-  background: var(--btn);
-  color: var(--text);
-  border-radius: var(--radius) 0 0 var(--radius);
-  cursor: pointer;
-  padding: 0;
-}
-
-#toggleEditor:hover {
-  background: var(--btn-hover);
-}
 
 #graph {
   flex: 1;
   height: 100%;
-}
-
-#editor {
-  width: 300px;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  border-left: 1px solid var(--panel);
-  background: var(--panel);
-  padding: var(--gap);
-  border-top-right-radius: var(--radius);
-}
-
-#editor h2 {
-  margin: 0;
-  padding-bottom: var(--gap);
-  border-bottom: 1px solid var(--panel);
-  font-size: 15px;
-  font-weight: bold;
-}
-
-#title {
-  background: var(--bg);
-  color: var(--text);
-  border: none;
-  border-bottom: 1px solid var(--panel);
-  padding: var(--gap);
-  font-size: 1rem;
 }
 
 #projectName {
@@ -186,79 +136,6 @@ header {
   gap: 0.25rem;
 }
 
-#formatting-toolbar {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.25rem 0;
-  border-bottom: 1px solid var(--panel);
-  background: var(--panel);
-  position: relative;
-}
-
-.color-button {
-  width: 20px;
-  height: 20px;
-  border: none;
-  border-radius: 3px;
-  cursor: pointer;
-}
-
-.color-picker {
-  position: absolute;
-  top: 100%;
-  right: 0;
-  display: grid;
-  grid-template-columns: repeat(4, 20px);
-  gap: 4px;
-  padding: 4px;
-  background: var(--panel);
-  border: 1px solid var(--panel);
-  border-radius: var(--radius);
-  z-index: 10;
-}
-
-.color-swatch {
-  width: 20px;
-  height: 20px;
-  border-radius: 3px;
-  cursor: pointer;
-  border: 1px solid #0003;
-}
-
-.reset-btn {
-  margin-left: 0.5rem;
-}
-
-#linear-toolbar {
-  display: flex;
-  gap: 0.25rem;
-  padding: 0.25rem;
-  border-bottom: 1px solid var(--panel);
-  background: var(--panel);
-  margin: 0 var(--gap);
-  overflow-x: auto;
-  white-space: nowrap;
-}
-
-#text {
-  flex: 1;
-  width: 100%;
-  border: none;
-  background: var(--bg);
-  color: var(--text);
-  font-family: 'Inter', sans-serif;
-  overflow-y: auto;
-  scrollbar-width: none;
-  -ms-overflow-style: none;
-}
-#text::-webkit-scrollbar {
-  display: none;
-}
-#text:focus {
-  outline: none;
-  box-shadow: none;
-}
 
 #modal {
   position: fixed;
@@ -707,21 +584,6 @@ textarea:focus {
 }
 
 @media (max-width: 768px) {
-  main {
-    grid-template-columns: 1fr;
-  }
-  #editor {
-    position: fixed;
-    top: 0;
-    right: 0;
-    height: 100vh;
-    width: 100vw;
-    max-width: none;
-    z-index: 1000;
-  }
-  #toggleEditor {
-    right: 0 !important;
-  }
   .react-flow__minimap {
     display: none;
   }


### PR DESCRIPTION
## Summary
- remove legacy inspector and return to a two-column layout
- allow LinearView panel to toggle between 30% and 80% width
- bump version to 0.0.23

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac2ab28c34832fac58561c574b9ab7