### PR TITLE
feat: sync node selection with linear view

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.23",
+  "version": "0.0.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/ActiveNodeHighlight.ts
+++ b/src/ActiveNodeHighlight.ts
@@ -1,0 +1,57 @@
+import { Extension } from '@tiptap/core'
+import { Plugin, PluginKey } from 'prosemirror-state'
+import { Decoration, DecorationSet } from 'prosemirror-view'
+
+const ActiveNodePluginKey = new PluginKey('active-node-highlight')
+
+const ActiveNodeHighlight = Extension.create({
+  name: 'activeNodeHighlight',
+
+  addCommands() {
+    return {
+      setActiveNodeId:
+        id =>
+        ({ state, dispatch }) => {
+          const tr = state.tr.setMeta(ActiveNodePluginKey, id)
+          dispatch(tr)
+          return true
+        },
+    }
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: ActiveNodePluginKey,
+        state: {
+          init: () => null,
+          apply(tr, value) {
+            const meta = tr.getMeta(ActiveNodePluginKey)
+            return meta !== undefined ? meta : value
+          },
+        },
+        props: {
+          decorations(state) {
+            const activeId = ActiveNodePluginKey.getState(state)
+            if (!activeId) return null
+            const { doc } = state
+            const decorations: Decoration[] = []
+            const target = `#${activeId}`
+            doc.descendants((node, pos) => {
+              if (node.type.name === 'heading' && node.textContent.startsWith(target)) {
+                decorations.push(
+                  Decoration.node(pos, pos + node.nodeSize, { class: 'is-active-node' })
+                )
+                return false
+              }
+            })
+            return DecorationSet.create(doc, decorations)
+          },
+        },
+      }),
+    ]
+  },
+})
+
+export default ActiveNodeHighlight
+

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,6 +107,7 @@ export default function App() {
     return stored ? Number(stored) : 14
   })
   const [theme, setTheme] = useState(() => localStorage.getItem('vv-theme') || 'dark')
+  const [activeNodeId, setActiveNodeId] = useState(null)
   const importRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
   const undoStack = useRef([])
@@ -480,6 +481,7 @@ export default function App() {
     setCurrentId(node.id)
     setText(node.data.text || '')
     setTitle(node.data.title || '')
+    setActiveNodeId(node.id)
   }
 
   const onPaneClick = e => {
@@ -491,6 +493,7 @@ export default function App() {
     setCurrentId(null)
     setText('')
     setTitle('')
+    setActiveNodeId(null)
   }
 
   const updateNodeText = useCallback(
@@ -926,6 +929,7 @@ export default function App() {
           nextId={nextId}
           expanded={isPanelExpanded}
           onToggleExpand={() => setIsPanelExpanded(e => !e)}
+          activeNodeId={activeNodeId}
         />
       </main>
       {showPlay && (

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -11,6 +11,7 @@ import EditorBubbleMenu from './EditorBubbleMenu.jsx'
 import useLinearParser from './useLinearParser.ts'
 import 'tippy.js/dist/tippy.css'
 import { Extension } from '@tiptap/core'
+import ActiveNodeHighlight from './ActiveNodeHighlight.ts'
 
 const KeyboardShortcuts = Extension.create({
   name: 'keyboardShortcuts',
@@ -24,7 +25,7 @@ const KeyboardShortcuts = Extension.create({
   },
 })
 
-export default function LinearView({ text, setText, setNodes, nextId, expanded, onToggleExpand }) {
+export default function LinearView({ text, setText, setNodes, nextId, expanded, onToggleExpand, activeNodeId }) {
   const editor = useEditor({
     extensions: [
       StarterKit.configure({ bulletList: false, orderedList: false, listItem: false }),
@@ -34,6 +35,7 @@ export default function LinearView({ text, setText, setNodes, nextId, expanded, 
       Markdown.configure({ html: false }),
       BubbleMenuExtension,
       KeyboardShortcuts,
+      ActiveNodeHighlight,
     ],
     content: text || '',
     onUpdate({ editor }) {
@@ -144,6 +146,7 @@ export default function LinearView({ text, setText, setNodes, nextId, expanded, 
         .scrollIntoView()
         .run()
       setActiveId(id)
+      editor.commands.setActiveNodeId(id)
     }
   }, [editor])
 
@@ -164,6 +167,15 @@ export default function LinearView({ text, setText, setNodes, nextId, expanded, 
     root.addEventListener('click', handle)
     return () => root.removeEventListener('click', handle)
   }, [jumpTo])
+
+  useEffect(() => {
+    if (!editor) return
+    if (activeNodeId) {
+      jumpTo(activeNodeId)
+    } else {
+      editor.commands.setActiveNodeId(null)
+    }
+  }, [activeNodeId, editor, jumpTo])
 
   useEffect(() => {
     const container = mainRef.current

--- a/src/index.css
+++ b/src/index.css
@@ -562,6 +562,12 @@ header {
   color: var(--text);
 }
 
+.is-active-node {
+  background: var(--btn);
+  color: var(--text);
+  transition: background-color 0.3s;
+}
+
 .linear-footer {
   border-color: var(--panel);
 }


### PR DESCRIPTION
## Summary
- scroll Linear View to selected graph node
- highlight active node text via Tiptap decoration
- bump version to 0.0.24

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac338d5f60832fb5928ea44920c436