### PR TITLE
chore: log node activation and highlight

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.23",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.23",
+    "version": "0.0.25",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.24",
+  "version": "0.0.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -481,6 +481,7 @@ export default function App() {
     setCurrentId(node.id)
     setText(node.data.text || '')
     setTitle(node.data.title || '')
+    console.log('Node clicked, setting active ID:', node.id)
     setActiveNodeId(node.id)
   }
 

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -168,7 +168,10 @@ export default function LinearView({ text, setText, setNodes, nextId, expanded, 
     return () => root.removeEventListener('click', handle)
   }, [jumpTo])
 
+  console.log('LinearView received activeNodeId prop:', activeNodeId)
+
   useEffect(() => {
+    console.log('useEffect triggered for activeNodeId:', activeNodeId)
     if (!editor) return
     if (activeNodeId) {
       jumpTo(activeNodeId)

--- a/src/index.css
+++ b/src/index.css
@@ -563,9 +563,9 @@ header {
 }
 
 .is-active-node {
-  background: var(--btn);
-  color: var(--text);
-  transition: background-color 0.3s;
+  background-color: rgba(59, 130, 246, 0.2);
+  transition: background-color 0.3s ease;
+  border-radius: 4px;
 }
 
 .linear-footer {


### PR DESCRIPTION
## Summary
- style active nodes with a visible highlight
- log active node ID on click and in LinearView
- bump version to 0.0.25

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac36bb5c98832f8e862c050d2aa8a0