### PR TITLE
Fix node click handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.26",
+    "version": "0.0.27",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.26",
+  "version": "0.0.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -477,12 +477,16 @@ export default function App() {
     setTitle('')
   }
 
+  const selectNode = useCallback((id, data) => {
+    setCurrentId(id)
+    setText(data.text || '')
+    setTitle(data.title || '')
+    console.log('Node clicked, setting active ID:', id)
+    setActiveNodeId(id)
+  }, [])
+
   const onNodeClick = (_e, node) => {
-    setCurrentId(node.id)
-    setText(node.data.text || '')
-    setTitle(node.data.title || '')
-    console.log('Node clicked, setting active ID:', node.id)
-    setActiveNodeId(node.id)
+    selectNode(node.id, node.data)
   }
 
   const onPaneClick = e => {
@@ -896,7 +900,7 @@ export default function App() {
       <main className={`workspace ${isPanelExpanded ? 'expanded' : ''}`}>
         <div id="graph-container">
           <div id="graph">
-            <NodeEditorContext.Provider value={{ updateNodeText, resizingRef }}>
+            <NodeEditorContext.Provider value={{ updateNodeText, resizingRef, selectNode }}>
               <ReactFlow
                 style={{ width: '100%', height: '100%' }}
                 nodes={nodes}

--- a/src/NodeCard.jsx
+++ b/src/NodeCard.jsx
@@ -16,7 +16,7 @@ function isLightColor(hex) {
 
 const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height = DEFAULT_NODE_HEIGHT }) => {
   const { setNodes, getNodes, updateNodeInternals } = useReactFlow()
-  const { updateNodeText, resizingRef } = useContext(NodeEditorContext)
+  const { updateNodeText, resizingRef, selectNode } = useContext(NodeEditorContext)
   const [resizing, setResizing] = useState(false)
   const [overflow, setOverflow] = useState(false)
   const [invalidRef, setInvalidRef] = useState(false)
@@ -95,6 +95,7 @@ const NodeCard = memo(({ id, data, selected, width = DEFAULT_NODE_WIDTH, height 
   return (
     <div
       className={`node-card${selected ? ' selected' : ''}${resizing ? ' resizing' : ''}`}
+      onClick={() => selectNode(id, data)}
       style={{
         background: bg,
         color: textColor,

--- a/src/NodeEditorContext.ts
+++ b/src/NodeEditorContext.ts
@@ -7,11 +7,13 @@ export interface NodeEditorContextType {
    * clicks that would otherwise clear selection while a resize is in progress.
    */
   resizingRef: MutableRefObject<boolean>
+  selectNode: (id: string, data: { text?: string; title?: string }) => void
 }
 
 const NodeEditorContext = createContext<NodeEditorContextType>({
   updateNodeText: () => {},
   resizingRef: { current: false },
+  selectNode: () => {},
 })
 
 export default NodeEditorContext

--- a/src/__tests__/NodeClick.test.jsx
+++ b/src/__tests__/NodeClick.test.jsx
@@ -1,0 +1,38 @@
+/* eslint-env jest */
+/* global global, test, expect */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ReactFlow, { ReactFlowProvider } from 'reactflow';
+import { jest } from '@jest/globals';
+
+jest.mock('@reactflow/node-resizer', () => ({ NodeResizer: () => null }));
+
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+import NodeCard from '../NodeCard.jsx';
+import NodeEditorContext from '../NodeEditorContext.ts';
+
+const nodes = [
+  { id: '1', type: 'card', position: { x: 0, y: 0 }, data: { text: 'hello' } },
+];
+
+test('calls selectNode when node is clicked', () => {
+  const selectNode = jest.fn();
+  const { container } = render(
+    <NodeEditorContext.Provider value={{ updateNodeText: () => {}, resizingRef: { current: false }, selectNode }}>
+      <ReactFlowProvider>
+        <div style={{ width: 500, height: 500 }}>
+          <ReactFlow nodes={nodes} edges={[]} nodeTypes={{ card: NodeCard }} />
+        </div>
+      </ReactFlowProvider>
+    </NodeEditorContext.Provider>
+  );
+  const node = container.querySelector('.node-card');
+  fireEvent.click(node);
+  expect(selectNode).toHaveBeenCalledWith('1', expect.objectContaining({ text: 'hello' }));
+});

--- a/src/__tests__/NodeSize.test.jsx
+++ b/src/__tests__/NodeSize.test.jsx
@@ -26,7 +26,7 @@ const nodes = [
 
 it('keeps node dimensions after click', () => {
   const { container } = render(
-    <NodeEditorContext.Provider value={{ updateNodeText: () => {}, resizingRef: { current: false } }}>
+    <NodeEditorContext.Provider value={{ updateNodeText: () => {}, resizingRef: { current: false }, selectNode: () => {} }}>
       <ReactFlowProvider>
         <div style={{ width: 500, height: 500 }}>
           <ReactFlow


### PR DESCRIPTION
## Summary
- handle node selections by invoking `selectNode` directly from the node card
- expose `selectNode` in `NodeEditorContext`
- add regression test for node click and bump version to 0.0.27

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac3dc1201c832fbe1d1c9898151323