### PR TITLE
Sync node selection between graph and linear view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.28",
+    "version": "0.0.29",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.28",
+  "version": "0.0.29",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -481,13 +481,22 @@ export default function App() {
     setCurrentId(id)
     setText(data.text || '')
     setTitle(data.title || '')
-    console.log('Node clicked, setting active ID:', id)
     setActiveNodeId(id)
   }, [])
 
   const onNodeClick = (_e, node) => {
     selectNode(node.id, node.data)
   }
+
+  const handleLinearSelect = useCallback(
+    id => {
+      const node = nodes.find(n => n.id === id)
+      if (node) {
+        selectNode(node.id, node.data)
+      }
+    },
+    [nodes, selectNode]
+  )
 
   const onPaneClick = e => {
     const t = e.target
@@ -934,6 +943,7 @@ export default function App() {
           expanded={isPanelExpanded}
           onToggleExpand={() => setIsPanelExpanded(e => !e)}
           activeNodeId={activeNodeId}
+          onSelectNode={handleLinearSelect}
         />
       </main>
       {showPlay && (


### PR DESCRIPTION
## Summary
- Highlight corresponding linear entry when clicking a graph node
- Highlight graph node when selecting an outline entry
- Bump version to 0.0.29

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac5ab01b0c832f97beb590c41bf1b4