### PR TITLE
feat: add debug mode for node/linear interaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valj-vag-verktyg",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valj-vag-verktyg",
-    "version": "0.0.29",
+      "version": "0.0.30",
       "dependencies": {
         "@headlessui/react": "^2.2.4",
         "@heroicons/react": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.0.29",
+  "version": "0.0.30",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -40,6 +40,7 @@ import pkg from '../package.json'
 import NewProjectModal from './NewProjectModal.jsx'
 import { DEFAULT_NODE_WIDTH, DEFAULT_NODE_HEIGHT } from './constants.js'
 import useProjectStorage from './useProjectStorage.js'
+import { setDebug as setDebugFlag, debugLog, isDebug } from './utils/debug.js'
 
 const ROOT_KEY = '__root__'
 
@@ -108,11 +109,21 @@ export default function App() {
   })
   const [theme, setTheme] = useState(() => localStorage.getItem('vv-theme') || 'dark')
   const [activeNodeId, setActiveNodeId] = useState(null)
+  const [debugMode, setDebugMode] = useState(isDebug())
   const importRef = useRef(null)
   const reconnectInfo = useRef({ handleType: null, didReconnect: false })
   const undoStack = useRef([])
   const redoStack = useRef([])
   const resizingRef = useRef(false)
+  const toggleDebug = () => {
+    const next = !debugMode
+    setDebugMode(next)
+    setDebugFlag(next)
+  }
+
+  useEffect(() => {
+    debugLog('activeNodeId', activeNodeId)
+  }, [activeNodeId])
 
   useEffect(() => {
     document.documentElement.style.setProperty('--font-size', `${fontSize}px`)
@@ -478,6 +489,7 @@ export default function App() {
   }
 
   const selectNode = useCallback((id, data) => {
+    debugLog('selectNode', id)
     setCurrentId(id)
     setText(data.text || '')
     setTitle(data.title || '')
@@ -485,11 +497,13 @@ export default function App() {
   }, [])
 
   const onNodeClick = (_e, node) => {
+    debugLog('onNodeClick', node.id)
     selectNode(node.id, node.data)
   }
 
   const handleLinearSelect = useCallback(
     id => {
+      debugLog('handleLinearSelect', id)
       const node = nodes.find(n => n.id === id)
       if (node) {
         selectNode(node.id, node.data)
@@ -894,6 +908,13 @@ export default function App() {
           title="Increase font size"
         >
           A+
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={toggleDebug}
+          title="Toggle debug mode"
+        >
+          {debugMode ? 'Debug On' : 'Debug Off'}
         </Button>
         <Button
           variant="ghost"

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -12,6 +12,7 @@ import useLinearParser from './useLinearParser.ts'
 import 'tippy.js/dist/tippy.css'
 import { Extension } from '@tiptap/core'
 import ActiveNodeHighlight from './ActiveNodeHighlight.ts'
+import { debugLog } from './utils/debug.js'
 
 const KeyboardShortcuts = Extension.create({
   name: 'keyboardShortcuts',
@@ -132,6 +133,7 @@ export default function LinearView({
 
   const jumpTo = useCallback(
     id => {
+      debugLog('LinearView.jumpTo', id)
       if (!editor) return
 
       let targetPos = null
@@ -184,6 +186,7 @@ export default function LinearView({
 
   useEffect(() => {
     if (!editor) return
+    debugLog('LinearView activeNodeId effect', activeNodeId)
     if (activeNodeId) {
       jumpTo(activeNodeId)
     } else {

--- a/src/utils/debug.js
+++ b/src/utils/debug.js
@@ -1,0 +1,15 @@
+let enabled = false;
+
+export function setDebug(val) {
+  enabled = val;
+}
+
+export function isDebug() {
+  return enabled;
+}
+
+export function debugLog(...args) {
+  if (enabled) {
+    console.log('[debug]', ...args);
+  }
+}


### PR DESCRIPTION
## Summary
- add global debug utility and toggle to enable node/linear logs
- log node selections and Linear View navigation for easier troubleshooting
- bump version to 0.0.30

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac7d453c30832fb6c097b045a1172b