### PR TITLE
Replace Tailwind classes with plain CSS (v0.8.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valj-vag-verktyg",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/LinearView.jsx
+++ b/src/LinearView.jsx
@@ -223,43 +223,43 @@ export default function LinearView({
   const charCount = editor.storage.characterCount?.characters() || 0
 
   return (
-    <div id="linear-panel" className="linear-container flex flex-col h-full">
-      <header className="linear-header p-3 flex items-center justify-between border-b">
-        <div className="flex items-center gap-2">
+    <div id="linear-panel" className="linear-container">
+      <header className="linear-header">
+        <div className="linear-header-left">
           <button className="btn ghost" type="button" onClick={onToggleExpand}
             title={expanded ? 'Collapse' : 'Expand'}
             aria-label={expanded ? 'Collapse panel' : 'Expand panel'}>
             {expanded ? <ChevronRight /> : <ChevronLeft />}
           </button>
-          <h1 className="text-lg font-bold">Linear View</h1>
-          <span className="text-xs text-dim" style={{ opacity: 0.5 }}>
+          <h1 className="linear-header-title">Linear View</h1>
+          <span className="text-dim linear-header-stats">
             {wordCount} ord · {charCount} tecken
           </span>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="linear-header-right">
           <button className="btn" type="button" onClick={insertNewNode} aria-label="Ny nod">
             <Plus aria-hidden="true" />
           </button>
           <button className="btn" type="button" onClick={exportMarkdown}>
-            <Download className="h-4 w-4" /> Exportera
+            <Download /> Exportera
           </button>
         </div>
       </header>
 
       <EditorToolbar editor={editor} onInsertNode={insertNewNode} />
 
-      <div className="flex flex-1 min-h-0">
-        <aside className="hidden md:flex md:flex-col md:w-1/4 linear-sidebar h-full min-h-0">
-          <div className="flex-1 overflow-y-auto p-4 no-scrollbar">
-            <h2 className="text-sm font-semibold text-dim uppercase tracking-wider mb-4">
+      <div className="linear-body">
+        <aside className="linear-sidebar">
+          <div className="linear-sidebar-inner no-scrollbar">
+            <h2 className="linear-sidebar-heading text-dim">
               Outline
             </h2>
-            <ul className="space-y-1">
+            <ul className="outline-list">
               {outlineEntries.map(item => (
                 <li key={item.id}>
                   <button
                     type="button"
-                    className={`outline-btn block w-full text-left text-sm p-2 rounded-md ${
+                    className={`outline-btn ${
                       activeId === item.id ? 'active' : ''
                     }`}
                     onClick={() => jumpTo(item.id)}
@@ -271,12 +271,12 @@ export default function LinearView({
             </ul>
           </div>
         </aside>
-        <main className="flex-1 flex flex-col linear-main min-h-0 overflow-hidden">
+        <main className="linear-main">
           <div
             ref={mainRef}
-            className="flex-1 overflow-y-auto p-4 sm:p-8 md:p-12 no-scrollbar main-editor-container"
+            className="linear-main-scroll no-scrollbar main-editor-container"
           >
-            <div className="max-w-3xl mx-auto relative">
+            <div className="linear-editor-wrapper">
               {editor && <EditorBubbleMenu editor={editor} />}
               <EditorContent id="linearEditor" editor={editor} />
             </div>

--- a/src/index.css
+++ b/src/index.css
@@ -656,28 +656,136 @@ header {
 .linear-container {
   background: var(--modal-bg);
   color: var(--text);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .linear-header {
   background: var(--panel);
   color: var(--text);
   border-color: var(--panel);
+  padding: 0.75rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid var(--panel);
+}
+
+.linear-header-left,
+.linear-header-right {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.linear-header-right {
+  gap: 0.75rem;
+}
+
+.linear-header-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.linear-header-stats {
+  font-size: 0.75rem;
+  opacity: 0.5;
+}
+
+.linear-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
 }
 
 .linear-sidebar {
   background: var(--panel);
   border-color: var(--panel);
   color: var(--text);
+  display: none;
+  flex-direction: column;
+  width: 25%;
+  height: 100%;
+  min-height: 0;
+}
+
+@media (min-width: 768px) {
+  .linear-sidebar {
+    display: flex;
+  }
+}
+
+.linear-sidebar-inner {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+.linear-sidebar-heading {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 1rem;
+}
+
+.outline-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .linear-main {
   background: var(--bg);
   color: var(--text);
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.linear-main-scroll {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+}
+
+@media (min-width: 640px) {
+  .linear-main-scroll {
+    padding: 2rem;
+  }
+}
+
+@media (min-width: 768px) {
+  .linear-main-scroll {
+    padding: 3rem;
+  }
+}
+
+.linear-editor-wrapper {
+  max-width: 48rem;
+  margin-left: auto;
+  margin-right: auto;
+  position: relative;
 }
 
 .outline-btn {
   background: transparent;
   color: var(--text);
+  display: block;
+  width: 100%;
+  text-align: left;
+  font-size: 0.875rem;
+  padding: 0.5rem;
+  border-radius: 0.375rem;
+  border: none;
+  cursor: pointer;
 }
 .outline-btn:hover {
   background: var(--btn-hover);


### PR DESCRIPTION
v0.8.0 removed CDN Tailwind but kept utility classes in JSX. Now all replaced with semantic CSS.